### PR TITLE
Adding GitHub action to publish multi-arch docker image

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,4 @@ jobs:
             name: Build dockerfile (with push)
             run: |
                 docker buildx build \
-                --platform=linux/amd64,linux/arm/v7,linux/arm64 \
-                --output "type=image,push=true" \
-                --file ./Dockerfile . \
-                --tag $(echo "${DOCKER_USERNAME}" | tr '[:upper:]' '[:lower:]')/ttrss:latest
+                --platform=linux/amd64,linux/arm/v7,linux/arm64 --file ./Dockerfile

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: '[builder] CI for releases'
 on:
     push:
         branches:
-            - main
+            - master
 
 jobs:
     release:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,13 +12,12 @@ jobs:
         -
             name: Checkout
             uses: docker/setup-buildx-action@v1.0.3
-#         -
-#             name: Dockerhub login
-#             env:
-#                 DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-#                 DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-#             run: |
-#                 echo "${DOCKER_PASSWORD}" | docker login --username ${DOCKER_USERNAME} --password-stdin
+        -
+            name: Login to DockerHub
+            uses: docker/login-action@v1 
+            with:
+                username: ${{ secrets.DOCKERHUB_USERNAME }}
+                password: ${{ secrets.DOCKERHUB_TOKEN }}
         -
             name: Checkout
             uses: actions/checkout@v2
@@ -39,6 +38,12 @@ jobs:
             with:
                 version: latest
         -
-            name: Build dockerfile (with push)
-            run: |
-                docker buildx build --platform linux/amd64,linux/arm64 .
+            name: Build and push
+            uses: docker/build-push-action@v2
+            with:
+                context: .
+                file: ./Dockerfile
+                platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/ppc64le,linux/s390x
+                push: true
+                tags: |
+                    zubairov/mqtt-exporter:latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,4 +35,4 @@ jobs:
                 platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/ppc64le,linux/s390x
                 push: true
                 tags: |
-                    zubairov/${{ secrets.DOCKERHUB_USERNAME }}:latest
+                    ${{ secrets.DOCKERHUB_USERNAME }}/mqtt-exporter:latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,4 +35,4 @@ jobs:
                 platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/ppc64le,linux/s390x
                 push: true
                 tags: |
-                    zubairov/mqtt-exporter:latest
+                    zubairov/${{ secrets.DOCKERHUB_USERNAME }}:latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,13 +12,13 @@ jobs:
         -
             name: Checkout
             uses: docker/setup-buildx-action@v1.0.3
-        -
-            name: Dockerhub login
-            env:
-                DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-                DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-            run: |
-                echo "${DOCKER_PASSWORD}" | docker login --username ${DOCKER_USERNAME} --password-stdin
+#         -
+#             name: Dockerhub login
+#             env:
+#                 DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+#                 DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+#             run: |
+#                 echo "${DOCKER_PASSWORD}" | docker login --username ${DOCKER_USERNAME} --password-stdin
         -
             name: Checkout
             uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,18 +25,13 @@ jobs:
             name: Set up QEMU
             id: qemu
             uses: docker/setup-qemu-action@v1
-            with:
-                image: tonistiigi/binfmt:latest
-                platforms: all
         -
             name: Available platforms
             run: echo ${{ steps.qemu.outputs.platforms }}
         -
             name: Set up Docker Buildx
             id: buildx
-            uses: crazy-max/ghaction-docker-buildx@v1
-            with:
-                version: latest
+            uses: docker/setup-buildx-action@v1
         -
             name: Build and push
             uses: docker/build-push-action@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,48 @@
+name: '[builder] CI for releases'
+
+on:
+    push:
+        branches:
+            - main
+
+jobs:
+    release:
+        runs-on: ubuntu-latest
+        steps:
+        -
+            name: Checkout
+            uses: docker/setup-buildx-action@v1.0.3
+        -
+            name: Dockerhub login
+            env:
+                DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+                DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+            run: |
+                echo "${DOCKER_PASSWORD}" | docker login --username ${DOCKER_USERNAME} --password-stdin
+        -
+            name: Checkout
+            uses: actions/checkout@v2
+        -
+            name: Set up QEMU
+            id: qemu
+            uses: docker/setup-qemu-action@v1
+            with:
+                image: tonistiigi/binfmt:latest
+                platforms: all
+        -
+            name: Available platforms
+            run: echo ${{ steps.qemu.outputs.platforms }}
+        -
+            name: Set up Docker Buildx
+            id: buildx
+            uses: crazy-max/ghaction-docker-buildx@v1
+            with:
+                version: latest
+        -
+            name: Build dockerfile (with push)
+            run: |
+                docker buildx build \
+                --platform=linux/amd64,linux/arm/v7,linux/arm64 \
+                --output "type=image,push=true" \
+                --file ./Dockerfile . \
+                --tag $(echo "${DOCKER_USERNAME}" | tr '[:upper:]' '[:lower:]')/ttrss:latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,5 +41,4 @@ jobs:
         -
             name: Build dockerfile (with push)
             run: |
-                docker buildx build \
-                --platform=linux/amd64,linux/arm/v7,linux/arm64 --file ./Dockerfile
+                docker buildx build --platform linux/amd64,linux/arm64 .

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: '[builder] CI for releases'
+name: 'Build and publish docker images (all platforms)'
 
 on:
     push:
@@ -11,7 +11,7 @@ jobs:
         steps:
         -
             name: Checkout
-            uses: docker/setup-buildx-action@v1.0.3
+            uses: actions/checkout@v2
         -
             name: Login to DockerHub
             uses: docker/login-action@v1 
@@ -19,15 +19,9 @@ jobs:
                 username: ${{ secrets.DOCKERHUB_USERNAME }}
                 password: ${{ secrets.DOCKERHUB_TOKEN }}
         -
-            name: Checkout
-            uses: actions/checkout@v2
-        -
             name: Set up QEMU
             id: qemu
             uses: docker/setup-qemu-action@v1
-        -
-            name: Available platforms
-            run: echo ${{ steps.qemu.outputs.platforms }}
         -
             name: Set up Docker Buildx
             id: buildx


### PR DESCRIPTION
Unfortunately, the docker image `kpetrem/mqtt-exporter` has only one arch hence does not work under other architectures (e.g. on Raspberry PI). Adding this file to the repository will automatically build and publish images on dockerhub for all available architectures. No additional costs will apply as it's based on Github Actions.

Please change the last line of the `main.yml` to place the correct dockerhub username.