### PR TITLE
Fix: Don't crash when not able to decode payload.

### DIFF
--- a/exporter.py
+++ b/exporter.py
@@ -35,6 +35,9 @@ def expose_metrics(client, userdata, msg):  # pylint: disable=W0613
     except json.JSONDecodeError:
         LOG.debug('failed to parse as JSON: "%s"', msg.payload)
         return
+    except UnicodeDecodeError:
+        LOG.debug('encountered undecodable payload: "%s"', msg.payload)
+        return
 
     # we except a dict from zigbee metrics in MQTT
     if not isinstance(payload, dict):

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,2 +1,3 @@
 paho-mqtt
 prometheus-client
+re


### PR DESCRIPTION
Disclaimer: These are the first three lines of Python I've ever written.

I encountered a `UnicodeDecodeError: 'utf-8' codec can't decode byte 0x8b in position 1: invalid start byte` when trying to use this exporter with data from my Xiaomi Roborock vacuum. It's probably the `map_data` which I don't care about anyway, so this was my fix.

<img width="606" alt="Screenshot 2021-02-13 at 14 34 48" src="https://user-images.githubusercontent.com/294558/107851226-b925fb80-6e08-11eb-92b1-ba828a2dcf82.png">


