### PR TITLE
Fix: Don't crash when not able to decode payload.

### DIFF
--- a/exporter.py
+++ b/exporter.py
@@ -35,6 +35,9 @@ def expose_metrics(client, userdata, msg):  # pylint: disable=W0613
     except json.JSONDecodeError:
         LOG.debug('failed to parse as JSON: "%s"', msg.payload)
         return
+    except UnicodeDecodeError:
+        LOG.debug('encountered undecodable payload: "%s"', msg.payload)
+        return
 
     # we except a dict from zigbee metrics in MQTT
     if not isinstance(payload, dict):


### PR DESCRIPTION
(Copied from https://github.com/kpetremann/mqtt-exporter/pull/8 )

Disclaimer: These are the first three lines of Python I've ever written.

I encountered a `UnicodeDecodeError: 'utf-8' codec can't decode byte 0x8b in position 1: invalid start byte` when trying to use this exporter with data from my Xiaomi Roborock vacuum. It's probably the `map_data` which I don't care about anyway, so this was my fix.

<img width="606" alt="Screenshot 2021-02-13 at 14 34 48" src="https://user-images.githubusercontent.com/294558/107857240-893d1f00-6e2d-11eb-8a9e-e9a12d6fa8d3.png">

