### PR TITLE
main: match ignored topics with fnmatch instead of equality

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ mqtt_humidity{topic="zigbee2mqtt_0x00157d00032b1234"} 45.37
 Parameters are passed using environment variables.
 
 The list of parameters are:
-  * `IGNORED_TOPICS`: Comma-separated lists of topics to ignore (default: None)
   * `LOG_LEVEL`: Logging level (default: INFO)
+  * `MQTT_IGNORED_TOPICS`: Comma-separated lists of topics to ignore. Accepts wildcards. (default: None)
   * `MQTT_ADDRESS`: IP or hostname of MQTT broker (default: 127.0.0.1)
   * `MQTT_PORT`: TCP port of MQTT broker (default: 1883)
   * `MQTT_TOPIC`: Topic path to subscribe to (default: #)

--- a/mqtt_exporter/main.py
+++ b/mqtt_exporter/main.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """MQTT exporter."""
 
+import fnmatch
 import json
 import logging
 import re
@@ -154,9 +155,10 @@ def _parse_message(raw_topic, raw_payload):
 
 def expose_metrics(client, userdata, msg):  # pylint: disable=W0613
     """Expose metrics to prometheus when a message has been published (callback)."""
-    if msg.topic in settings.IGNORED_TOPICS:
-        LOG.debug('Topic "%s" was ignored', msg.topic)
-        return
+    for ignore in settings.IGNORED_TOPICS:
+        if fnmatch.fnmatch(msg.topic, ignore):
+            LOG.debug('Topic "%s" was ignored by entry "%s"', msg.topic, ignore)
+            return
 
     topic, payload = _parse_message(msg.topic, msg.payload)
 


### PR DESCRIPTION
This PR allows to define topics to ignore using wildcards (`*`, `?`) rather than requiring an exact match. This patch should be backwards-compatible as exact match should still happen if there are no wildcards present.

A single `*` will match across `/` separators: `*excludeme*` will exclude `foo/excludeme/bar`.

As a side note, I have fixed the env var being documented with an incorrect name in `README.md`.