### PR TITLE
Expose Clientid and add MQTT v5 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ The list of parameters are:
   * `MQTT_KEEPALIVE`: Keep alive interval to maintain connection with MQTT broker (default: 60)
   * `MQTT_USERNAME`: Username which should be used to authenticate against the MQTT broker (default: None)
   * `MQTT_PASSWORD`: Password which should be used to authenticate against the MQTT broker (default: None)
+  * `MQTT_V5_PROTOCOL`: Force to use MQTT protocol v5 instead of 3.1.1
+  * `MQTT_CLIENT_ID`: Set client ID manually for MQTT connection
+  * `MQTT_EXPOSE_CLIENT_ID`: Expose the client ID as a label in Prometheus metrics
   * `PROMETHEUS_PORT`: HTTP server PORT to expose Prometheus metrics (default: 9000)
   * `PROMETHEUS_PREFIX`: Prefix added to the metric name, example: mqtt_temperature (default: mqtt_)
   * `TOPIC_LABEL`: Define the Prometheus label for the topic, example temperature{topic="device1"} (default: topic)

--- a/mqtt_exporter/main.py
+++ b/mqtt_exporter/main.py
@@ -43,8 +43,8 @@ else:
 
 def subscribe(client, _, __, result_code, *args):
     """Subscribe to mqtt events (callback)."""
-    user_data = {"client_id": ""}
-    if args:
+    user_data = {"client_id": settings.MQTT_CLIENT_ID}
+    if not settings.MQTT_CLIENT_ID and args:
         user_data["client_id"] = args[0].AssignedClientIdentifier
 
     client.user_data_set(user_data)
@@ -224,10 +224,10 @@ def expose_metrics(_, userdata, msg):
 def main():
     """Start the exporter."""
     if settings.MQTT_V5_PROTOCOL:
-        client = mqtt.Client(protocol=mqtt.MQTTv5)
+        client = mqtt.Client(client_id=settings.MQTT_CLIENT_ID, protocol=mqtt.MQTTv5)
     else:
         # if MQTT version 5 is not requesteed, we let mqtt lib choosing the protocol version
-        client = mqtt.Client()
+        client = mqtt.Client(client_id=settings.MQTT_CLIENT_ID)
 
     def stop_request(signum, frame):
         """Stop handler for SIGTERM and SIGINT.

--- a/mqtt_exporter/settings.py
+++ b/mqtt_exporter/settings.py
@@ -14,5 +14,6 @@ MQTT_KEEPALIVE = int(os.getenv("MQTT_KEEPALIVE", "60"))
 MQTT_USERNAME = os.getenv("MQTT_USERNAME")
 MQTT_PASSWORD = os.getenv("MQTT_PASSWORD")
 MQTT_V5_PROTOCOL = os.getenv("MQTT_V5_PROTOCOL", "False") == "True"
+MQTT_CLIENT_ID = os.getenv("MQTT_CLIENT_ID", "")
 MQTT_EXPOSE_CLIENT_ID = os.getenv("MQTT_EXPOSE_CLIENT_ID", "False") == "True"
 PROMETHEUS_PORT = int(os.getenv("PROMETHEUS_PORT", "9000"))

--- a/mqtt_exporter/settings.py
+++ b/mqtt_exporter/settings.py
@@ -13,4 +13,6 @@ MQTT_PORT = int(os.getenv("MQTT_PORT", "1883"))
 MQTT_KEEPALIVE = int(os.getenv("MQTT_KEEPALIVE", "60"))
 MQTT_USERNAME = os.getenv("MQTT_USERNAME")
 MQTT_PASSWORD = os.getenv("MQTT_PASSWORD")
+MQTT_V5_PROTOCOL = os.getenv("MQTT_V5_PROTOCOL", "False") == "True"
+MQTT_EXPOSE_CLIENT_ID = os.getenv("MQTT_EXPOSE_CLIENT_ID", "False") == "True"
 PROMETHEUS_PORT = int(os.getenv("PROMETHEUS_PORT", "9000"))

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,1 +1,2 @@
 pytest
+pytest-mock

--- a/tests/functional/test_expose_metrics.py
+++ b/tests/functional/test_expose_metrics.py
@@ -1,0 +1,67 @@
+"""Functional tests of MQTT metrics."""
+
+import prometheus_client
+
+from mqtt_exporter import main, settings
+
+
+def _reset():
+    # pylama: ignore=W0212
+    collectors = list(prometheus_client.REGISTRY._collector_to_names.keys())
+    for collector in collectors:
+        prometheus_client.REGISTRY.unregister(collector)
+
+
+def _exec(client_id, mocker):
+    _reset()
+    settings.MQTT_CLIENT_ID = client_id
+    main._create_msg_counter_metrics()
+    main.prom_metrics = {}
+    userdata = {"client_id": client_id}
+    msg = mocker.Mock()
+    msg.topic = "zigbee2mqtt/garage"
+    msg.payload = '{"temperature": "23.5", "humidity": "40.5"}'
+    main.expose_metrics(None, userdata, msg)
+
+    temperatures = main.prom_metrics["mqtt_temperature"].collect()
+    humidity = main.prom_metrics["mqtt_humidity"].collect()
+
+    return temperatures, humidity
+
+
+def test_expose_metrics__default(mocker):
+    """Tests with no client ID, client ID not exposed."""
+    settings.MQTT_EXPOSE_CLIENT_ID = False
+    temperatures, humidity = _exec("", mocker)
+
+    assert len(temperatures) == 1
+    assert len(temperatures[0].samples) == 1
+    assert temperatures[0].samples[0].value == 23.5
+    assert temperatures[0].samples[0].labels == {"topic": "zigbee2mqtt_garage"}
+
+    assert len(humidity) == 1
+    assert len(humidity[0].samples) == 1
+    assert humidity[0].samples[0].value == 40.5
+    assert humidity[0].samples[0].labels == {"topic": "zigbee2mqtt_garage"}
+
+
+def test_expose_metrics__default_client_set_exposed(mocker):
+    """Tests with client ID, client ID exposed."""
+    settings.MQTT_EXPOSE_CLIENT_ID = True
+    temperatures, humidity = _exec("clienttestid", mocker)
+
+    assert len(temperatures) == 1
+    assert len(temperatures[0].samples) == 1
+    assert temperatures[0].samples[0].value == 23.5
+    assert temperatures[0].samples[0].labels == {
+        "client_id": "clienttestid",
+        "topic": "zigbee2mqtt_garage",
+    }
+
+    assert len(humidity) == 1
+    assert len(humidity[0].samples) == 1
+    assert humidity[0].samples[0].value == 40.5
+    assert humidity[0].samples[0].labels == {
+        "client_id": "clienttestid",
+        "topic": "zigbee2mqtt_garage",
+    }


### PR DESCRIPTION
Feature request #24 

- MQTTv5 protocol support to have client ID auto generated
- be able to set client ID for any MQTT protocol version
- be able to expose client ID

The client ID will remain empty if client id = "" and MQTTv5 disabled.