### PR TITLE
fix "Invalid metric name" when topic contains »-«

### DIFF
--- a/mqtt_exporter/main.py
+++ b/mqtt_exporter/main.py
@@ -129,7 +129,11 @@ def _parse_metrics(data, topic, client_id, prefix=""):
             continue
 
         # create metric if does not exist
-        prom_metric_name = f"{settings.PREFIX}{prefix}{metric}".replace(".", "").replace(" ", "_")
+        prom_metric_name = (
+            f"{settings.PREFIX}{prefix}{metric}".replace(".", "")
+            .replace(" ", "_")
+            .replace("-", "_")
+        )
         prom_metric_name = re.sub(r"\((.*?)\)", "", prom_metric_name)
         _create_prometheus_metric(prom_metric_name)
 

--- a/tests/functional/test_parse_message.py
+++ b/tests/functional/test_parse_message.py
@@ -76,3 +76,33 @@ def test_parse_message__nested():
             "Current": 0.784,
         },
     }
+
+
+def test_parse_message__nested_with_dash_in_metric_name():
+    """Test message parsing when dash in metric name.
+
+    seen with tasmota + multiple DS18B20 sensors.
+    """
+    topic = "tele/balcony/SENSOR"
+    payload = '{ \
+        "Time": "2022-07-01T21:21:17", \
+        "DS18B20-1": { \
+            "Id": "022EDB070007", \
+            "Temperature": 15.9 \
+        }, \
+        "DS18B20-2": { \
+            "Id": "0316A279C254", \
+            "Temperature": 6.9 \
+        }, \
+        "TempUnit": "C" \
+    }'
+
+    parsed_topic, parsed_payload = _parse_message(topic, payload)
+
+    assert parsed_topic == "tele_balcony_SENSOR"
+    assert parsed_payload == {
+        "Time": "2022-07-01T21:21:17",
+        "DS18B20-1": {"Id": "022EDB070007", "Temperature": 15.9},
+        "DS18B20-2": {"Id": "0316A279C254", "Temperature": 6.9},
+        "TempUnit": "C",
+    }

--- a/tests/functional/test_parse_metrics.py
+++ b/tests/functional/test_parse_metrics.py
@@ -1,0 +1,20 @@
+"""Functional tests of metrics parsing."""
+from mqtt_exporter.main import _parse_metrics
+
+
+def test_parse_metrics__nested_with_dash_in_metric_name():
+    """Test metrics parsing when dash in metric name.
+
+    seen with tasmota + multiple DS18B20 sensors.
+
+    refers to test_parse_message__nested_with_dash_in_metric_name()
+    """
+    parsed_topic = "tele_balcony_SENSOR"
+    parsed_payload = {
+        "Time": "2022-07-01T21:21:17",
+        "DS18B20-1": {"Id": "022EDB070007", "Temperature": 15.9},
+        "DS18B20-2": {"Id": "0316A279C254", "Temperature": 6.9},
+        "TempUnit": "C",
+    }
+
+    _parse_metrics(parsed_payload, parsed_topic, "dummy_client_id")


### PR DESCRIPTION
after fix:
 INFO:mqtt-exporter:creating prometheus metric: z2m_DS18B20_1_Temperature
 INFO:mqtt-exporter:creating prometheus metric: z2m_DS18B20_2_Temperature

before fix:
[...]
 INFO:mqtt-exporter:creating prometheus metric: z2m_Dimmer1
 INFO:mqtt-exporter:creating prometheus metric: z2m_Dimmer2
 Traceback (most recent call last):
   File "/opt/mqtt-exporter/exporter.py", line 5, in <module>
     main()
   File "/opt/mqtt-exporter/mqtt_exporter/main.py", line 202, in main
     client.loop_forever()
   File "/usr/local/lib/python3.9/site-packages/paho/mqtt/client.py", line 1756, in loop_forever
     rc = self._loop(timeout)
   File "/usr/local/lib/python3.9/site-packages/paho/mqtt/client.py", line 1164, in _loop
     rc = self.loop_read()
   File "/usr/local/lib/python3.9/site-packages/paho/mqtt/client.py", line 1556, in loop_read
     rc = self._packet_read()
   File "/usr/local/lib/python3.9/site-packages/paho/mqtt/client.py", line 2439, in _packet_read
     rc = self._packet_handle()
   File "/usr/local/lib/python3.9/site-packages/paho/mqtt/client.py", line 3033, in _packet_handle
     return self._handle_publish()
   File "/usr/local/lib/python3.9/site-packages/paho/mqtt/client.py", line 3327, in _handle_publish
     self._handle_on_message(message)
   File "/usr/local/lib/python3.9/site-packages/paho/mqtt/client.py", line 3570, in _handle_on_message
     on_message(self, self._userdata, message)
   File "/opt/mqtt-exporter/mqtt_exporter/main.py", line 166, in expose_metrics
     _parse_metrics(payload, topic)
   File "/opt/mqtt-exporter/mqtt_exporter/main.py", line 47, in _parse_metrics
     _parse_metrics(value, topic, f"{prefix}{metric}_")
   File "/opt/mqtt-exporter/mqtt_exporter/main.py", line 60, in _parse_metrics
     prom_metrics[prom_metric_name] = Gauge(
   File "/usr/local/lib/python3.9/site-packages/prometheus_client/metrics.py", line 355, in __init__
     super(Gauge, self).__init__(
   File "/usr/local/lib/python3.9/site-packages/prometheus_client/metrics.py", line 123, in __init__
     raise ValueError('Invalid metric name: ' + self._name)
 ValueError: Invalid metric name: z2m_DS18B20-1_Id

and
 [...]
 INFO:mqtt-exporter:creating prometheus metric: z2m_ENERGY_Current
 Traceback (most recent call last):
   File "/opt/mqtt-exporter/exporter.py", line 5, in <module>
     main()
   File "/opt/mqtt-exporter/mqtt_exporter/main.py", line 266, in main
     client.loop_forever()
   File "/usr/local/lib/python3.9/site-packages/paho/mqtt/client.py", line 1756, in loop_forever
     rc = self._loop(timeout)
   File "/usr/local/lib/python3.9/site-packages/paho/mqtt/client.py", line 1164, in _loop
     rc = self.loop_read()
   File "/usr/local/lib/python3.9/site-packages/paho/mqtt/client.py", line 1556, in loop_read
     rc = self._packet_read()
   File "/usr/local/lib/python3.9/site-packages/paho/mqtt/client.py", line 2439, in _packet_read
     rc = self._packet_handle()
   File "/usr/local/lib/python3.9/site-packages/paho/mqtt/client.py", line 3033, in _packet_handle
     return self._handle_publish()
   File "/usr/local/lib/python3.9/site-packages/paho/mqtt/client.py", line 3327, in _handle_publish
     self._handle_on_message(message)
   File "/usr/local/lib/python3.9/site-packages/paho/mqtt/client.py", line 3570, in _handle_on_message
     on_message(self, self._userdata, message)
   File "/opt/mqtt-exporter/mqtt_exporter/main.py", line 221, in expose_metrics
     _parse_metrics(payload, topic, userdata["client_id"])
   File "/opt/mqtt-exporter/mqtt_exporter/main.py", line 122, in _parse_metrics
     _parse_metrics(value, topic, client_id, f"{prefix}{metric}_")
   File "/opt/mqtt-exporter/mqtt_exporter/main.py", line 134, in _parse_metrics
     _create_prometheus_metric(prom_metric_name)
   File "/opt/mqtt-exporter/mqtt_exporter/main.py", line 71, in _create_prometheus_metric
     prom_metrics[prom_metric_name] = Gauge(
   File "/usr/local/lib/python3.9/site-packages/prometheus_client/metrics.py", line 365, in __init__
     super().__init__(
   File "/usr/local/lib/python3.9/site-packages/prometheus_client/metrics.py", line 130, in __init__
     raise ValueError('Invalid metric name: ' + self._name)
 ValueError: Invalid metric name: z2m_DS18B20-1_Temperature