### PR TITLE
Debug: log MQTT message (optional)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Parameters are passed using environment variables.
 
 The list of parameters are:
   * `LOG_LEVEL`: Logging level (default: INFO)
+  * `LOG_MQTT_MESSAGE`: Log MQTT original message, only if LOG_LEVEL is set to DEBUG (default: False)
   * `MQTT_IGNORED_TOPICS`: Comma-separated lists of topics to ignore. Accepts wildcards. (default: None)
   * `MQTT_ADDRESS`: IP or hostname of MQTT broker (default: 127.0.0.1)
   * `MQTT_PORT`: TCP port of MQTT broker (default: 1883)

--- a/mqtt_exporter/main.py
+++ b/mqtt_exporter/main.py
@@ -249,6 +249,8 @@ def expose_metrics(_, userdata, msg):
             LOG.debug('Topic "%s" was ignored by entry "%s"', msg.topic, ignore)
             return
 
+    logging.debug("New message from MQTT: %s - %s", msg.topic, msg.payload)
+
     topic, payload = _parse_message(msg.topic, msg.payload)
 
     if not topic or not payload:

--- a/mqtt_exporter/main.py
+++ b/mqtt_exporter/main.py
@@ -249,7 +249,8 @@ def expose_metrics(_, userdata, msg):
             LOG.debug('Topic "%s" was ignored by entry "%s"', msg.topic, ignore)
             return
 
-    logging.debug("New message from MQTT: %s - %s", msg.topic, msg.payload)
+    if settings.LOG_MQTT_MESSAGE:
+        LOG.debug("New message from MQTT: %s - %s", msg.topic, msg.payload)
 
     topic, payload = _parse_message(msg.topic, msg.payload)
 

--- a/mqtt_exporter/settings.py
+++ b/mqtt_exporter/settings.py
@@ -9,6 +9,7 @@ ZWAVE_TOPIC_PREFIX = os.getenv("ZWAVE_TOPIC_PREFIX", "zwave/")
 
 ZIGBEE2MQTT_AVAILABILITY = os.getenv("ZIGBEE2MQTT_AVAILABILITY", "False") == "True"
 LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO")
+LOG_MQTT_MESSAGE = os.getenv("LOG_MQTT_MESSAGE", "False") == "True"
 MQTT_ADDRESS = os.getenv("MQTT_ADDRESS", "127.0.0.1")
 MQTT_PORT = int(os.getenv("MQTT_PORT", "1883"))
 MQTT_KEEPALIVE = int(os.getenv("MQTT_KEEPALIVE", "60"))


### PR DESCRIPTION
The goal of this PR is to make debugging easier, especially for support.

It logs in debug MQTT original topic and payload (disabled by default).