### PR TITLE
Added functionality to extract metric name and labels from topic

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ To setup this, you need to specify the topic prefix used by Zwavejs2Mqtt in `ZWA
 Parameters are passed using environment variables.
 
 The list of parameters are:
+  * `ADDITIONAL_LABELS`: If set to True then additional labels will be retrieved from topic (default: False)
+  * `ADDITIONAL_LABELS_REGEX`: Regular expression to extract additional labels (default: None). This setting is required is `ADDITIONAL_LABELS` is set to True.
   * `LOG_LEVEL`: Logging level (default: INFO)
   * `LOG_MQTT_MESSAGE`: Log MQTT original message, only if LOG_LEVEL is set to DEBUG (default: False)
   * `MQTT_IGNORED_TOPICS`: Comma-separated lists of topics to ignore. Accepts wildcards. (default: None)
@@ -97,6 +99,8 @@ The list of parameters are:
   * `MQTT_EXPOSE_CLIENT_ID`: Expose the client ID as a label in Prometheus metrics
   * `PROMETHEUS_PORT`: HTTP server PORT to expose Prometheus metrics (default: 9000)
   * `PROMETHEUS_PREFIX`: Prefix added to the metric name, example: mqtt_temperature (default: mqtt_)
+  * `SEPARATE_METRICS`: If set to True then every topic will generate separate metric (default: False)
+  * `SEPARATE_METRIC_ID_REGEX`: You can override default regular expression used to extract metric name from topic (defaul: '(?P<metric_id>.*)')
   * `TOPIC_LABEL`: Define the Prometheus label for the topic, example temperature{topic="device1"} (default: topic)
   * `ZIGBEE2MQTT_AVAILABILITY`: Normalize sensor name for device availability metric added by Zigbee2MQTT (default: False)
   * `ZWAVE_TOPIC_PREFIX`: MQTT topic used for Zwavejs2Mqtt messages (default: zwave/)

--- a/mqtt_exporter/settings.py
+++ b/mqtt_exporter/settings.py
@@ -1,12 +1,15 @@
 """Exporter configuration."""
 import os
 
+SEPARATE_METRICS = os.getenv("SEPARATE_METRICS", "False") == "True"
+SEPARATE_METRIC_ID_REGEX = os.getenv("SEPARATE_METRIC_ID_REGEX", "(?P<metric_id>.*)")
+ADDITIONAL_LABELS = os.getenv("ADDITIONAL_LABELS", "False") == "True"
+ADDITIONAL_LABELS_REGEX = os.getenv("ADDITIONAL_LABELS_REGEX")
 PREFIX = os.getenv("PROMETHEUS_PREFIX", "mqtt_")
 TOPIC_LABEL = os.getenv("TOPIC_LABEL", "topic")
 TOPIC = os.getenv("MQTT_TOPIC", "#")
 IGNORED_TOPICS = os.getenv("MQTT_IGNORED_TOPICS", "").split(",")
 ZWAVE_TOPIC_PREFIX = os.getenv("ZWAVE_TOPIC_PREFIX", "zwave/")
-
 ZIGBEE2MQTT_AVAILABILITY = os.getenv("ZIGBEE2MQTT_AVAILABILITY", "False") == "True"
 LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO")
 LOG_MQTT_MESSAGE = os.getenv("LOG_MQTT_MESSAGE", "False") == "True"


### PR DESCRIPTION
I've implemented functionality to extract additional data from topic (labels and metric identifier) by using regular expression. 
This addition can be useful with ESPHome MQTT client 'cause it generate topics that ends with 'state' for every sensor. Also it has parametrized topic prefix that can be used to extract additional labels for metric, i.e. location, device type etc.

* Added SEPARATE_METRICS parameter to extract metric identifier from topic with regular expression defined in SEPARATE_METRIC_ID_REGEX parameter.
* Added ADDITIONAL_LABELS parameters to extract labels from topic with regular expression defined in ADDITIONAL_LABELS_REGEX parameter.