### PR TITLE
fix: Exception when metric key has a slash in it

### DIFF
--- a/mqtt_exporter/main.py
+++ b/mqtt_exporter/main.py
@@ -133,6 +133,7 @@ def _parse_metrics(data, topic, client_id, prefix=""):
             f"{settings.PREFIX}{prefix}{metric}".replace(".", "")
             .replace(" ", "_")
             .replace("-", "_")
+            .replace("/", "_")
         )
         prom_metric_name = re.sub(r"\((.*?)\)", "", prom_metric_name)
         _create_prometheus_metric(prom_metric_name)

--- a/tests/functional/test_parse_metrics.py
+++ b/tests/functional/test_parse_metrics.py
@@ -20,7 +20,7 @@ def test_parse_metrics__nested_with_dash_in_metric_name():
     _parse_metrics(parsed_payload, parsed_topic, "dummy_client_id")
 
 def test_metrics_escaping():
-    """"Verify that all keys are escaped properly"""
+    """Verify that all keys are escaped properly"""
     main.prom_metrics = {}
     parsed_topic = "test_topic"
     parsed_payload = {

--- a/tests/functional/test_parse_metrics.py
+++ b/tests/functional/test_parse_metrics.py
@@ -22,7 +22,7 @@ def test_parse_metrics__nested_with_dash_in_metric_name():
 
 
 def test_metrics_escaping():
-    """Verify that all keys are escaped properly"""
+    """Verify that all keys are escaped properly."""
     main.prom_metrics = {}
     parsed_topic = "test_topic"
     parsed_payload = {
@@ -30,6 +30,7 @@ def test_metrics_escaping():
         "test_value-b": 37,
         "test_value c": 13,
     }
+    # pylama: ignore=W0212
     main._parse_metrics(parsed_payload, parsed_topic, "dummy_client_id")
 
     assert "mqtt_test_value_a" in main.prom_metrics

--- a/tests/functional/test_parse_metrics.py
+++ b/tests/functional/test_parse_metrics.py
@@ -2,6 +2,7 @@
 from mqtt_exporter import main
 from mqtt_exporter.main import _parse_metrics
 
+
 def test_parse_metrics__nested_with_dash_in_metric_name():
     """Test metrics parsing when dash in metric name.
 
@@ -18,6 +19,7 @@ def test_parse_metrics__nested_with_dash_in_metric_name():
     }
 
     _parse_metrics(parsed_payload, parsed_topic, "dummy_client_id")
+
 
 def test_metrics_escaping():
     """Verify that all keys are escaped properly"""

--- a/tests/functional/test_parse_metrics.py
+++ b/tests/functional/test_parse_metrics.py
@@ -1,6 +1,6 @@
 """Functional tests of metrics parsing."""
+from mqtt_exporter import main
 from mqtt_exporter.main import _parse_metrics
-
 
 def test_parse_metrics__nested_with_dash_in_metric_name():
     """Test metrics parsing when dash in metric name.
@@ -18,3 +18,18 @@ def test_parse_metrics__nested_with_dash_in_metric_name():
     }
 
     _parse_metrics(parsed_payload, parsed_topic, "dummy_client_id")
+
+def test_metrics_escaping():
+    """"Verify that all keys are escaped properly"""
+    main.prom_metrics = {}
+    parsed_topic = "test_topic"
+    parsed_payload = {
+        "test_value/a": 42,
+        "test_value-b": 37,
+        "test_value c": 13,
+    }
+    main._parse_metrics(parsed_payload, parsed_topic, "dummy_client_id")
+
+    assert "mqtt_test_value_a" in main.prom_metrics
+    assert "mqtt_test_value_b" in main.prom_metrics
+    assert "mqtt_test_value_c" in main.prom_metrics


### PR DESCRIPTION
This PR resolves the following exception

<img width="874" alt="pr-error" src="https://user-images.githubusercontent.com/1064021/213968558-cd5f867b-8796-48f9-a4db-a19af4421ee6.png">
