### PR TITLE
add support for parsing values containing lists

### DIFF
--- a/mqtt_exporter/main.py
+++ b/mqtt_exporter/main.py
@@ -116,6 +116,12 @@ def _parse_metrics(data, topic, client_id, prefix=""):
     Note when `data` contains nested metrics this function will be called recursivley.
     """
     for metric, value in data.items():
+        # when value is a list recursivley call _parse_metrics to handle these messages
+        if isinstance(value, list):
+            LOG.debug("parsing list %s: %s", metric, value)
+            _parse_metrics(dict(enumerate(value)), topic, client_id, f"{prefix}{metric}_")
+            continue
+
         # when value is a dict recursivley call _parse_metrics to handle these messages
         if isinstance(value, dict):
             LOG.debug("parsing dict %s: %s", metric, value)

--- a/tests/functional/test_parse_metrics.py
+++ b/tests/functional/test_parse_metrics.py
@@ -42,9 +42,7 @@ def test_parse_metrics__value_is_list():
     """Verify if list recursion works properly."""
     main.prom_metrics = {}
     parsed_topic = "test_topic"
-    parsed_payload = {
-        "test_value": [1, 2]
-    }
+    parsed_payload = {"test_value": [1, 2]}
     main._parse_metrics(parsed_payload, parsed_topic, "dummy_client_id")
     assert "mqtt_test_value_0" in main.prom_metrics
     assert "mqtt_test_value_1" in main.prom_metrics

--- a/tests/functional/test_parse_metrics.py
+++ b/tests/functional/test_parse_metrics.py
@@ -37,12 +37,13 @@ def test_metrics_escaping():
     assert "mqtt_test_value_b" in main.prom_metrics
     assert "mqtt_test_value_c" in main.prom_metrics
 
+
 def test_parse_metrics__value_is_list():
     """Verify if list recursion works properly."""
     main.prom_metrics = {}
     parsed_topic = "test_topic"
     parsed_payload = {
-        "test_value": [1,2]
+        "test_value": [1, 2]
     }
     main._parse_metrics(parsed_payload, parsed_topic, "dummy_client_id")
     assert "mqtt_test_value_0" in main.prom_metrics

--- a/tests/functional/test_parse_metrics.py
+++ b/tests/functional/test_parse_metrics.py
@@ -36,3 +36,14 @@ def test_metrics_escaping():
     assert "mqtt_test_value_a" in main.prom_metrics
     assert "mqtt_test_value_b" in main.prom_metrics
     assert "mqtt_test_value_c" in main.prom_metrics
+
+def test_parse_metrics__value_is_list():
+    """Verify if list recursion works properly."""
+    main.prom_metrics = {}
+    parsed_topic = "test_topic"
+    parsed_payload = {
+        "test_value": [1,2]
+    }
+    main._parse_metrics(parsed_payload, parsed_topic, "dummy_client_id")
+    assert "mqtt_test_value_0" in main.prom_metrics
+    assert "mqtt_test_value_1" in main.prom_metrics


### PR DESCRIPTION
Shelly 3EM running Tasmota sends following. This patch enables mqtt-exporter to extract values from lists.

Before:
DEBUG:mqtt-exporter:Failed to convert Power: Can't parse '[148, 133, 106]' to a number.

Now:
DEBUG:mqtt-exporter:parsing list Power: [104, 133, 107]
DEBUG:mqtt-exporter:new value for mqtt_ENERGY_Power_0: 104
DEBUG:mqtt-exporter:new value for mqtt_ENERGY_Power_1: 133
DEBUG:mqtt-exporter:new value for mqtt_ENERGY_Power_2: 107

MQTT message:
{
  "Time": "2023-01-28T01:08:31",
  "ENERGY": {
    "TotalStartTime": "2023-01-23T23:19:38",
    "Total": 2.785,
    "Yesterday": 1.748,
    "Today": 1.037,
    "TodaySumImport": 1.037,
    "TodaySumExport": 0,
    "ExportActive": [
      0,
      0,
      0
    ],
    "Period": [
      12,
      11,
      9
    ],
    "Power": [
      97,
      133,
      107
    ],
    "ApparentPower": [
      153,
      182,
      214
    ],
    "ReactivePower": [
      118,
      125,
      186
    ],
    "Factor": [
      0.64,
      0.73,
      0.5
    ],
    "Frequency": [
      50,
      50,
      50
    ],
    "Voltage": [
      231,
      227,
      234
    ],
    "Current": [
      0.66,
      0.803,
      0.917
    ],
    "CurrentNeutral": 0.011
  }
}