### PR TITLE
Support TLS with optional CA validation

### DIFF
--- a/mqtt_exporter/main.py
+++ b/mqtt_exporter/main.py
@@ -7,10 +7,10 @@ import logging
 import re
 import signal
 import sys
+import ssl
 
 import paho.mqtt.client as mqtt
 from prometheus_client import Counter, Gauge, start_http_server
-
 from mqtt_exporter import settings
 
 logging.basicConfig(level=settings.LOG_LEVEL)
@@ -311,6 +311,20 @@ def main():
     else:
         # if MQTT version 5 is not requesteed, we let mqtt lib choosing the protocol version
         client = mqtt.Client(client_id=settings.MQTT_CLIENT_ID)
+
+    client.enable_logger(LOG)
+
+    if settings.MQTT_ENABLE_TLS:
+        LOG.debug("Enabling TLS on MQTT client")
+        ssl_context = ssl.create_default_context()
+        ssl_context.load_default_certs()
+
+        if settings.MQTT_TLS_NO_VERIFY:
+            LOG.debug("Not verifying MQTT certificate authority is trusted")
+            ssl_context.check_hostname = False
+            ssl_context.verify_mode = ssl.CERT_NONE
+
+    client.tls_set_context(ssl_context)
 
     def stop_request(signum, frame):
         """Stop handler for SIGTERM and SIGINT.

--- a/mqtt_exporter/main.py
+++ b/mqtt_exporter/main.py
@@ -8,8 +8,8 @@ import re
 import signal
 import sys
 import ssl
-
 import paho.mqtt.client as mqtt
+
 from prometheus_client import Counter, Gauge, start_http_server
 from mqtt_exporter import settings
 

--- a/mqtt_exporter/settings.py
+++ b/mqtt_exporter/settings.py
@@ -19,6 +19,8 @@ MQTT_PASSWORD = os.getenv("MQTT_PASSWORD")
 MQTT_V5_PROTOCOL = os.getenv("MQTT_V5_PROTOCOL", "False") == "True"
 MQTT_CLIENT_ID = os.getenv("MQTT_CLIENT_ID", "")
 MQTT_EXPOSE_CLIENT_ID = os.getenv("MQTT_EXPOSE_CLIENT_ID", "False") == "True"
+MQTT_ENABLE_TLS = os.getenv("MQTT_ENABLE_TLS", "False") == "True"
+MQTT_TLS_NO_VERIFY = os.getenv("MQTT_TLS_NO_VERIFY", "False") == "True"
 PROMETHEUS_PORT = int(os.getenv("PROMETHEUS_PORT", "9000"))
 
 KEEP_FULL_TOPIC = os.getenv("KEEP_FULL_TOPIC", "False") == "True"


### PR DESCRIPTION
<!-- Please respect the guidelines - codestyle and unit tests - explained in CONTRIBUTING.md -->

Fixes/Implement: TLS support for MQTT endoints

**Description:**

<!-- Put here a simple description on what the change is supposed to do -->

This PR will allow you to connect to TLS secured MQTT endpoints. It also allows you to disable verification of the server's certificate if it is not signed by an trusted CA.

**Before the commit:**

<!-- When relevant, please provide output, screenshot or example before the change -->

```
mqtt-exporter_1  | Traceback (most recent call last):
mqtt-exporter_1  |   File "/opt/mqtt-exporter/exporter.py", line 5, in <module>
mqtt-exporter_1  |     main()
mqtt-exporter_1  |   File "/opt/mqtt-exporter/mqtt_exporter/main.py", line 353, in main
mqtt-exporter_1  |     client.connect(settings.MQTT_ADDRESS, settings.MQTT_PORT, settings.MQTT_KEEPALIVE)
mqtt-exporter_1  |   File "/usr/local/lib/python3.10/site-packages/paho/mqtt/client.py", line 914, in connect
mqtt-exporter_1  |     return self.reconnect()
mqtt-exporter_1  |   File "/usr/local/lib/python3.10/site-packages/paho/mqtt/client.py", line 1073, in reconnect
mqtt-exporter_1  |     sock.do_handshake()
mqtt-exporter_1  |   File "/usr/local/lib/python3.10/ssl.py", line 1342, in do_handshake
mqtt-exporter_1  |     self._sslobj.do_handshake()
mqtt-exporter_1  | ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self-signed certificate in certificate chain (_ssl.c:1007)
```

**After the commit:**

<!-- When relevant, please provide output, screenshot or example after the change -->

```
DEBUG:mqtt-exporter:Enabling TLS on MQTT client
DEBUG:mqtt-exporter:Not verifying MQTT certificate authority is trusted
DEBUG:mqtt-exporter:Sending CONNECT (u1, p1, wr0, wq0, wf0, c1, k60) client_id=b''
DEBUG:mqtt-exporter:Received CONNACK (0, 0)
INFO:mqtt-exporter:subscribing to "<REDACTED>"
DEBUG:mqtt-exporter:Sending SUBSCRIBE (d0, m1) [(b'<REDACTED>', 0)]
DEBUG:mqtt-exporter:Received SUBACK
```