### PR TITLE
ci: migrate from pylama to ruff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,8 @@ jobs:
                 python -m pip install --upgrade pip
                 pip install -r requirements/dev.txt
         -
-            name: Lint with Pylama
-            run: pylama .
+            name: Lint with Ruff
+            run: ruff .
         -
             name: Lint with Black
             run: black . --check --diff

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ coverage.xml
 *.cover
 .hypothesis/
 .pytest_cache/
+.ruff_cache/
 
 # Translations
 *.mo

--- a/mqtt_exporter/main.py
+++ b/mqtt_exporter/main.py
@@ -27,20 +27,20 @@ STATE_VALUES = {
 }
 
 # global variable
-prom_metrics = {}  # pylint: disable=C0103
-prom_msg_counter = None  # pylint: disable=C0103
+prom_metrics = {}
+prom_msg_counter = None
 
 
 def _create_msg_counter_metrics():
-    global prom_msg_counter  # pylint: disable=W0603, C0103
+    global prom_msg_counter  # noqa: PLW0603
     if settings.MQTT_EXPOSE_CLIENT_ID:
-        prom_msg_counter = Counter(
+        prom_msg_counter = Counter(  # noqa: PLW0603
             f"{settings.PREFIX}message_total",
             "Counter of received messages",
             [settings.TOPIC_LABEL, "client_id"],
         )
     else:
-        prom_msg_counter = Counter(
+        prom_msg_counter = Counter(  # noqa: PLW0603
             f"{settings.PREFIX}message_total",
             "Counter of received messages",
             [settings.TOPIC_LABEL],

--- a/pylama.ini
+++ b/pylama.ini
@@ -1,9 +1,0 @@
-[pylama]
-skip={toxworkdir}/*,build/*,.tox/*,env/*,.env/*,venv/*,.venv/*
-linters=pylint,pycodestyle,pydocstyle
-
-[pylama:pydocstyle]
-ignore=D100,D203,D213,D405,D407,D413
-
-[pylama:pycodestyle]
-max_line_length = 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,55 @@
 [tool.black]
 line-length = 100
 exclude = "venv/"
+
+[tool.isort]
+profile = "black"
+multi_line_output = 3
+skip_gitignore = true
+skip = ".bzr,.direnv,.eggs,.git,.hg,.mypy_cache,.nox,.pants.d,.svn,.tox,.venv,_build,buck-out,build,dist,node_modules,venv,migrations,urls.py"
+
+[tool.ruff]
+select = [
+    "E",     # pycodestyle errors
+    "W",     # pycodestyle warnings
+    "F",     # pyflakes
+    "C",     # flake8-comprehensions
+    "B",     # flake8-bugbear
+    "C4",    # flake8-comprehensions
+    "G",     # flake8-logging-format
+    "S",     # bandit
+    "PL"     # pylint
+]
+ignore = [
+    "E501",     # line too long, handled by black
+    "C901",     # function is too complex
+    "PLR2004",  # magic value used in comparison
+    "PLR1711",  # useless `return` statement at end of function
+    "PLC1901",  # compare-to-empty-string
+    "PLR0911",  # too many return statements
+    "PLR0912",  # too many branches
+    "PLR0915",  # too many statements
+    "B009",     # do not call getattr with a constant attribute value
+    "B904",     # raise without from inside except
+]
+line-length = 100
+
+[tool.ruff.pylint]
+max-args = 10
+
+[tool.ruff.per-file-ignores]
+"__init__.py" = ["F401"]
+"tests/*.py" = ["E402", "S", "PL"]
+
+[tool.mypy]
+# error whenever it encounters a function definition without type annotations
+disallow_untyped_defs = true
+# error whenever a function with type annotations calls a function defined without annotations
+disallow_untyped_calls = true
+# stop treating arguments with a None default value as having an implicit Optional type
+no_implicit_optional = true
+# error whenever your code uses an unnecessary cast that can safely be removed
+warn_redundant_casts = true
+
+[tool.pytest.ini_options]
+asyncio_mode = "strict"

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,10 +1,5 @@
 -r base.txt
 -r tests.txt
-black
 invoke
-isort
 pdbpp
 pre-commit
-pydocstyle<6.2.0  # because of https://github.com/PyCQA/pydocstyle/issues/621
-pylama
-pylint

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,2 +1,6 @@
+black
+isort
+pylint
 pytest
 pytest-mock
+ruff


### PR DESCRIPTION
Pylama does not seem to be maintained anymore (pydocstyle compatibility issues are not addressed etc...).

Plus, ruff is way more faster!