### PR TITLE
Attach UserProperties as labels to metrics when using MQTTv5 protocol

### DIFF
--- a/mqtt_exporter/main.py
+++ b/mqtt_exporter/main.py
@@ -91,17 +91,14 @@ def _normalize_prometheus_metric_label_name(prom_metric_label_name):
 
     https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels
     """
-    if prom_metric_label_name.startswith("__"):
-        prom_metric_label_name = prom_metric_label_name[1:]
-    if metrics.METRIC_LABEL_NAME_RE.match(prom_metric_label_name):
-        return prom_metric_label_name
-
     # clean invalid characters
     prom_metric_label_name = re.sub(r"[^a-zA-Z0-9_]", "", prom_metric_label_name)
 
     # ensure to start with valid character
     if not re.match(r"^[a-zA-Z_]", prom_metric_label_name):
         prom_metric_label_name = "_" + prom_metric_label_name
+    if prom_metric_label_name.startswith("__"):
+        prom_metric_label_name = prom_metric_label_name[1:]
 
     return prom_metric_label_name
 

--- a/mqtt_exporter/main.py
+++ b/mqtt_exporter/main.py
@@ -91,6 +91,8 @@ def _normalize_prometheus_metric_label_name(prom_metric_label_name):
 
     https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels
     """
+    if prom_metric_label_name.startswith("__"):
+        prom_metric_label_name = prom_metric_label_name[1:]
     if metrics.METRIC_LABEL_NAME_RE.match(prom_metric_label_name):
         return prom_metric_label_name
 

--- a/mqtt_exporter/main.py
+++ b/mqtt_exporter/main.py
@@ -100,7 +100,7 @@ def _normalize_prometheus_metric_label_name(prom_metric_label_name):
     prom_metric_label_name = re.sub(r"[^a-zA-Z0-9_]", "", prom_metric_label_name)
 
     # ensure to start with valid character
-    if not re.match(r"^[a-zA-Z_:]", prom_metric_label_name):
+    if not re.match(r"^[a-zA-Z_]", prom_metric_label_name):
         prom_metric_label_name = "_" + prom_metric_label_name
 
     return prom_metric_label_name

--- a/mqtt_exporter/main.py
+++ b/mqtt_exporter/main.py
@@ -35,7 +35,7 @@ prom_msg_counter = None
 @dataclass(frozen=True)
 class PromMetricId:
     name: str
-    labels: tuple[str] = ()
+    labels: tuple = ()
 
 
 def _create_msg_counter_metrics():

--- a/mqtt_exporter/main.py
+++ b/mqtt_exporter/main.py
@@ -7,6 +7,7 @@ import logging
 import re
 import signal
 import sys
+from dataclasses import dataclass
 
 import paho.mqtt.client as mqtt
 from prometheus_client import Counter, Gauge, metrics, start_http_server
@@ -29,6 +30,12 @@ STATE_VALUES = {
 # global variable
 prom_metrics = {}
 prom_msg_counter = None
+
+
+@dataclass(frozen=True)
+class PromMetricId:
+    name: str
+    labels: tuple[str] = ()
 
 
 def _create_msg_counter_metrics():
@@ -79,29 +86,49 @@ def _normalize_prometheus_metric_name(prom_metric_name):
     return prom_metric_name
 
 
-def _create_prometheus_metric(prom_metric_name):
+def _normalize_prometheus_metric_label_name(prom_metric_label_name):
+    """Transform an invalid prometheus metric to a valid one.
+
+    https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels
+    """
+    if metrics.METRIC_LABEL_NAME_RE.match(prom_metric_label_name):
+        return prom_metric_label_name
+
+    # clean invalid characters
+    prom_metric_label_name = re.sub(r"[^a-zA-Z0-9_]", "", prom_metric_label_name)
+
+    # ensure to start with valid character
+    if not re.match(r"^[a-zA-Z_:]", prom_metric_label_name):
+        prom_metric_label_name = "_" + prom_metric_label_name
+
+    return prom_metric_label_name
+
+
+def _create_prometheus_metric(prom_metric_id):
     """Create Prometheus metric if does not exist."""
-    if not prom_metrics.get(prom_metric_name):
+    if not prom_metrics.get(prom_metric_id):
         labels = [settings.TOPIC_LABEL]
         if settings.MQTT_EXPOSE_CLIENT_ID:
             labels.append("client_id")
+        labels.extend(prom_metric_id.labels)
 
-        prom_metrics[prom_metric_name] = Gauge(
-            prom_metric_name, "metric generated from MQTT message.", labels
+        prom_metrics[prom_metric_id] = Gauge(
+            prom_metric_id.name, "metric generated from MQTT message.", labels
         )
-        LOG.info("creating prometheus metric: %s", prom_metric_name)
+        LOG.info("creating prometheus metric: %s", prom_metric_id)
 
 
-def _add_prometheus_sample(topic, prom_metric_name, metric_value, client_id):
-    if prom_metric_name not in prom_metrics:
+def _add_prometheus_sample(topic, prom_metric_id, metric_value, client_id, additional_labels):
+    if prom_metric_id not in prom_metrics:
         return
 
     labels = {settings.TOPIC_LABEL: topic}
     if settings.MQTT_EXPOSE_CLIENT_ID:
         labels["client_id"] = client_id
+    labels.update(additional_labels)
 
-    prom_metrics[prom_metric_name].labels(**labels).set(metric_value)
-    LOG.debug("new value for %s: %s", prom_metric_name, metric_value)
+    prom_metrics[prom_metric_id].labels(**labels).set(metric_value)
+    LOG.debug("new value for %s: %s", prom_metric_id, metric_value)
 
 
 def _parse_metric(data):
@@ -131,22 +158,25 @@ def _parse_metric(data):
     raise ValueError(f"Can't parse '{data}' to a number.")
 
 
-def _parse_metrics(data, topic, client_id, prefix=""):
+def _parse_metrics(data, topic, client_id, prefix="", labels=None):
     """Attempt to parse a set of metrics.
 
-    Note when `data` contains nested metrics this function will be called recursivley.
+    Note when `data` contains nested metrics this function will be called recursively.
     """
+    if labels is None:
+        labels = {}
+    label_keys = tuple(sorted(labels.keys()))
     for metric, value in data.items():
-        # when value is a list recursivley call _parse_metrics to handle these messages
+        # when value is a list recursively call _parse_metrics to handle these messages
         if isinstance(value, list):
             LOG.debug("parsing list %s: %s", metric, value)
-            _parse_metrics(dict(enumerate(value)), topic, client_id, f"{prefix}{metric}_")
+            _parse_metrics(dict(enumerate(value)), topic, client_id, f"{prefix}{metric}_", labels)
             continue
 
-        # when value is a dict recursivley call _parse_metrics to handle these messages
+        # when value is a dict recursively call _parse_metrics to handle these messages
         if isinstance(value, dict):
             LOG.debug("parsing dict %s: %s", metric, value)
-            _parse_metrics(value, topic, client_id, f"{prefix}{metric}_")
+            _parse_metrics(value, topic, client_id, f"{prefix}{metric}_", labels)
             continue
 
         try:
@@ -164,14 +194,15 @@ def _parse_metrics(data, topic, client_id, prefix=""):
         )
         prom_metric_name = re.sub(r"\((.*?)\)", "", prom_metric_name)
         prom_metric_name = _normalize_prometheus_metric_name(prom_metric_name)
+        prom_metric_id = PromMetricId(prom_metric_name, label_keys)
         try:
-            _create_prometheus_metric(prom_metric_name)
+            _create_prometheus_metric(prom_metric_id)
         except ValueError as error:
-            LOG.error("unable to create prometheus metric '%s': %s", prom_metric_name, error)
+            LOG.error("unable to create prometheus metric '%s': %s", prom_metric_id, error)
             return
 
         # expose the sample to prometheus
-        _add_prometheus_sample(topic, prom_metric_name, metric_value, client_id)
+        _add_prometheus_sample(topic, prom_metric_id, metric_value, client_id, labels)
 
 
 def _normalize_name_in_topic_msg(topic, payload):
@@ -331,6 +362,14 @@ def _parse_message(raw_topic, raw_payload):
     return topic, payload
 
 
+def _parse_properties(properties):
+    """Convert MQTTv5 properties to a dict."""
+    return {
+        _normalize_prometheus_metric_label_name(key): value
+        for key, value in properties.UserProperty
+    }
+
+
 def expose_metrics(_, userdata, msg):
     """Expose metrics to prometheus when a message has been published (callback)."""
     for ignore in settings.IGNORED_TOPICS:
@@ -346,7 +385,11 @@ def expose_metrics(_, userdata, msg):
     if not topic or not payload:
         return
 
-    _parse_metrics(payload, topic, userdata["client_id"])
+    if settings.MQTT_V5_PROTOCOL:
+        additional_labels = _parse_properties(msg.properties)
+    else:
+        additional_labels = {}
+    _parse_metrics(payload, topic, userdata["client_id"], labels=additional_labels)
 
     # increment received message counter
     labels = {settings.TOPIC_LABEL: topic}

--- a/tests/functional/test_expose_metrics.py
+++ b/tests/functional/test_expose_metrics.py
@@ -1,8 +1,11 @@
 """Functional tests of MQTT metrics."""
 
 import prometheus_client
+from paho.mqtt.packettypes import PacketTypes
+from paho.mqtt.properties import Properties
 
 from mqtt_exporter import main, settings
+from mqtt_exporter.main import PromMetricId
 
 
 def _reset():
@@ -12,7 +15,7 @@ def _reset():
         prometheus_client.REGISTRY.unregister(collector)
 
 
-def _exec(client_id, mocker):
+def _exec(client_id, mocker, added_labels):
     _reset()
     settings.MQTT_CLIENT_ID = client_id
     main._create_msg_counter_metrics()
@@ -21,10 +24,21 @@ def _exec(client_id, mocker):
     msg = mocker.Mock()
     msg.topic = "zigbee2mqtt/garage"
     msg.payload = '{"temperature°C": "23.5", "humidity": "40.5"}'
+    if added_labels:
+        msg.properties = Properties(PacketTypes.PUBLISH)
+        msg.properties.UserProperty = [
+            ("label_key", "label_value"),
+            ("Weird#Label Key!", "Weird Label Value"),
+        ]
+        expected_label_keys = ("WeirdLabelKey", "label_key")
+    else:
+        expected_label_keys = ()
     main.expose_metrics(None, userdata, msg)
 
-    temperatures = main.prom_metrics["mqtt_temperatureC"].collect()
-    humidity = main.prom_metrics["mqtt_humidity"].collect()
+    temperatures = main.prom_metrics[
+        PromMetricId("mqtt_temperatureC", expected_label_keys)
+    ].collect()
+    humidity = main.prom_metrics[PromMetricId("mqtt_humidity", expected_label_keys)].collect()
 
     return temperatures, humidity
 
@@ -32,7 +46,7 @@ def _exec(client_id, mocker):
 def test_expose_metrics__default(mocker):
     """Tests with no client ID, client ID not exposed."""
     settings.MQTT_EXPOSE_CLIENT_ID = False
-    temperatures, humidity = _exec("", mocker)
+    temperatures, humidity = _exec("", mocker, False)
 
     assert len(temperatures) == 1
     assert len(temperatures[0].samples) == 1
@@ -48,7 +62,7 @@ def test_expose_metrics__default(mocker):
 def test_expose_metrics__default_client_set_exposed(mocker):
     """Tests with client ID, client ID exposed."""
     settings.MQTT_EXPOSE_CLIENT_ID = True
-    temperatures, humidity = _exec("clienttestid", mocker)
+    temperatures, humidity = _exec("clienttestid", mocker, False)
 
     assert len(temperatures) == 1
     assert len(temperatures[0].samples) == 1
@@ -65,3 +79,22 @@ def test_expose_metrics__default_client_set_exposed(mocker):
         "client_id": "clienttestid",
         "topic": "zigbee2mqtt_garage",
     }
+
+
+def test_expose_metrics__labels_from_user_properties(mocker):
+    """Test that labels in UserProperty are added to metrics."""
+    settings.MQTT_EXPOSE_CLIENT_ID = False
+    settings.MQTT_V5_PROTOCOL = True
+    temperatures, humidity = _exec("clienttestid", mocker, True)
+
+    expected_labels = {
+        "topic": "zigbee2mqtt_garage",
+        "label_key": "label_value",
+        "WeirdLabelKey": "Weird Label Value",
+    }
+
+    assert len(temperatures) == 1
+    assert temperatures[0].samples[0].labels == expected_labels
+
+    assert len(humidity) == 1
+    assert humidity[0].samples[0].labels == expected_labels

--- a/tests/functional/test_parse_metrics.py
+++ b/tests/functional/test_parse_metrics.py
@@ -1,6 +1,6 @@
 """Functional tests of metrics parsing."""
 from mqtt_exporter import main
-from mqtt_exporter.main import _parse_metrics
+from mqtt_exporter.main import PromMetricId, _parse_metrics
 
 
 def test_parse_metrics__nested_with_dash_in_metric_name():
@@ -33,9 +33,9 @@ def test_metrics_escaping():
     # pylama: ignore=W0212
     main._parse_metrics(parsed_payload, parsed_topic, "dummy_client_id")
 
-    assert "mqtt_test_value_a" in main.prom_metrics
-    assert "mqtt_test_value_b" in main.prom_metrics
-    assert "mqtt_test_value_c" in main.prom_metrics
+    assert PromMetricId("mqtt_test_value_a") in main.prom_metrics
+    assert PromMetricId("mqtt_test_value_b") in main.prom_metrics
+    assert PromMetricId("mqtt_test_value_c") in main.prom_metrics
 
 
 def test_parse_metrics__value_is_list():
@@ -44,5 +44,5 @@ def test_parse_metrics__value_is_list():
     parsed_topic = "test_topic"
     parsed_payload = {"test_value": [1, 2]}
     main._parse_metrics(parsed_payload, parsed_topic, "dummy_client_id")
-    assert "mqtt_test_value_0" in main.prom_metrics
-    assert "mqtt_test_value_1" in main.prom_metrics
+    assert PromMetricId("mqtt_test_value_0") in main.prom_metrics
+    assert PromMetricId("mqtt_test_value_1") in main.prom_metrics

--- a/tests/unit/test_normalize_prometheus_name.py
+++ b/tests/unit/test_normalize_prometheus_name.py
@@ -2,8 +2,8 @@
 import pytest
 
 from mqtt_exporter.main import (
-    _normalize_prometheus_metric_name,
     _normalize_prometheus_metric_label_name,
+    _normalize_prometheus_metric_name,
 )
 
 

--- a/tests/unit/test_normalize_prometheus_name.py
+++ b/tests/unit/test_normalize_prometheus_name.py
@@ -30,6 +30,8 @@ def test_normalize_prometheus_metric_name():
         ("__using_reserved_prefix", "_using_reserved_prefix"),
         ("1_start_with_number", "_1_start_with_number"),
         ("%start_with_invalid_char", "start_with_invalid_char"),
+        ("%__start_with_invalid_char", "_start_with_invalid_char"),
+        ("_%_start_with_invalid_char", "_start_with_invalid_char"),
     ],
 )
 def test_normalize_prometheus_metric_label_name(candidate, wanted):

--- a/tests/unit/test_normalize_prometheus_name.py
+++ b/tests/unit/test_normalize_prometheus_name.py
@@ -1,5 +1,10 @@
 """Tests of Prometheus normalization metrics."""
-from mqtt_exporter.main import _normalize_prometheus_metric_name
+import pytest
+
+from mqtt_exporter.main import (
+    _normalize_prometheus_metric_name,
+    _normalize_prometheus_metric_label_name,
+)
 
 
 def test_normalize_prometheus_metric_name():
@@ -13,3 +18,20 @@ def test_normalize_prometheus_metric_name():
 
     for candidate, wanted in tests.items():
         assert _normalize_prometheus_metric_name(candidate) == wanted
+
+
+@pytest.mark.parametrize(
+    "candidate, wanted",
+    [
+        ("1234invalid", "_1234invalid"),
+        ("valid1234", "valid1234"),
+        ("_this_is_valid", "_this_is_valid"),
+        ("not_so_valid%_name", "not_so_valid_name"),
+        ("__using_reserved_prefix", "_using_reserved_prefix"),
+        ("1_start_with_number", "_1_start_with_number"),
+        ("%start_with_invalid_char", "start_with_invalid_char"),
+    ],
+)
+def test_normalize_prometheus_metric_label_name(candidate, wanted):
+    """Test _normalize_prometheus_metric_label_name."""
+    assert _normalize_prometheus_metric_label_name(candidate) == wanted


### PR DESCRIPTION
<!-- Please respect the guidelines - codestyle and unit tests - explained in CONTRIBUTING.md -->

Fixes/Implement: #64 

**Description:**
When using MQTTv5, attach any UserProperties from the message as labels on the exposed metrics.
