### PR TITLE
Add basic pyproject properties & `PROMETHEUS_ADDRESS` setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ The list of parameters are:
   * `MQTT_V5_PROTOCOL`: Force to use MQTT protocol v5 instead of 3.1.1
   * `MQTT_CLIENT_ID`: Set client ID manually for MQTT connection
   * `MQTT_EXPOSE_CLIENT_ID`: Expose the client ID as a label in Prometheus metrics
+  * `PROMETHEUS_ADDRESS`: HTTP server address to expose Prometheus metrics on (default: 0.0.0.0)
   * `PROMETHEUS_PORT`: HTTP server PORT to expose Prometheus metrics (default: 9000)
   * `PROMETHEUS_PREFIX`: Prefix added to the metric name, example: mqtt_temperature (default: mqtt_)
   * `TOPIC_LABEL`: Define the Prometheus label for the topic, example temperature{topic="device1"} (default: topic)

--- a/mqtt_exporter/main.py
+++ b/mqtt_exporter/main.py
@@ -426,7 +426,7 @@ def main():
     signal.signal(signal.SIGINT, stop_request)
 
     # start prometheus server
-    start_http_server(settings.PROMETHEUS_PORT)
+    start_http_server(settings.PROMETHEUS_PORT, settings.PROMETHEUS_ADDRESS)
 
     # define mqtt client
     client.on_connect = subscribe

--- a/mqtt_exporter/settings.py
+++ b/mqtt_exporter/settings.py
@@ -21,6 +21,7 @@ MQTT_PASSWORD = os.getenv("MQTT_PASSWORD")
 MQTT_V5_PROTOCOL = os.getenv("MQTT_V5_PROTOCOL", "False") == "True"
 MQTT_CLIENT_ID = os.getenv("MQTT_CLIENT_ID", "")
 MQTT_EXPOSE_CLIENT_ID = os.getenv("MQTT_EXPOSE_CLIENT_ID", "False") == "True"
+PROMETHEUS_ADDRESS = os.getenv("PROMETHEUS_ADDRESS", "0.0.0.0")
 PROMETHEUS_PORT = int(os.getenv("PROMETHEUS_PORT", "9000"))
 
 KEEP_FULL_TOPIC = os.getenv("KEEP_FULL_TOPIC", "False") == "True"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,15 @@
+[project]
+name = "mqtt-exporter"
+version = "1.4.1"
+description = "Simple generic MQTT Prometheus exporter for IoT working out of the box"
+license = { text = "MIT License" }
+authors = [
+    { name = "Kevin Petremann", email = "kpetrem@gmail.com" },
+]
+
+[project.scripts]
+mqtt-exporter = "mqtt_exporter.main:main"
+
 [tool.black]
 line-length = 100
 exclude = "venv/"


### PR DESCRIPTION
<!-- Please respect the guidelines - codestyle and unit tests - explained in CONTRIBUTING.md -->

Fixes/Implement: -

**Description:**

First, add some basic properties in `pyproject.toml` as laid out in the [Python Packaging guide](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/). This helps distribution and such to easier package mqtt-exporter. 
Hopefully these are okay as-is.

Second, add a new, pretty straight-forward `PROMETHEUS_ADDRESS` setting, to be able to specify the address mqtt-exporter should listen on.
Users might want their mqtt-exporter to e.g. just listen on localhost, thereby also reducing the risk of accidentally exposing it to the network.

Cheers,
Christoph