### PR TITLE
CLI: Test tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,33 @@ If you need persistent metrics, I would advise using VictoriaMetrics. Of course 
 
 You can also add other cool software such as Home-Assistant.
 
+## CLI interactive test
+
+You can use the test mode to preview the conversion of a topic and payload to Prometheus metrics.
+
+Usage example:
+
+```
+$ python ./exporter.py --test
+topic: zigbee2mqtt/0x00157d00032b1234
+payload: {"temperature":26.24,"humidity":45.37}
+
+## Debug ##
+
+parsed to: zigbee2mqtt_0x00157d00032b1234 {'temperature': 26.24, 'humidity': 45.37}
+INFO:mqtt-exporter:creating prometheus metric: PromMetricId(name='mqtt_temperature', labels=())
+INFO:mqtt-exporter:creating prometheus metric: PromMetricId(name='mqtt_humidity', labels=())
+
+## Result ##
+
+# HELP mqtt_temperature metric generated from MQTT message.
+# TYPE mqtt_temperature gauge
+mqtt_temperature{topic="zigbee2mqtt_0x00157d00032b1234"} 26.24
+# HELP mqtt_humidity metric generated from MQTT message.
+# TYPE mqtt_humidity gauge
+mqtt_humidity{topic="zigbee2mqtt_0x00157d00032b1234"} 45.37
+```
+
 ## Contribute
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md).

--- a/mqtt_exporter/main.py
+++ b/mqtt_exporter/main.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """MQTT exporter."""
 
+import argparse
 import fnmatch
 import json
 import logging
@@ -11,7 +12,7 @@ import sys
 from dataclasses import dataclass
 
 import paho.mqtt.client as mqtt
-from prometheus_client import Counter, Gauge, metrics, start_http_server
+from prometheus_client import Counter, Gauge, metrics, start_http_server, generate_latest, REGISTRY
 
 from mqtt_exporter import settings
 
@@ -402,7 +403,7 @@ def expose_metrics(_, userdata, msg):
     prom_msg_counter.labels(**labels).inc()
 
 
-def main():
+def run():
     """Start the exporter."""
     if settings.MQTT_V5_PROTOCOL:
         client = mqtt.Client(
@@ -458,6 +459,36 @@ def main():
         client.username_pw_set(settings.MQTT_USERNAME, settings.MQTT_PASSWORD)
     client.connect(settings.MQTT_ADDRESS, settings.MQTT_PORT, settings.MQTT_KEEPALIVE)
     client.loop_forever()
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        prog="MQTT-exporter",
+        description="Simple generic MQTT Prometheus exporter for IoT working out of the box.",
+        epilog="https://github.com/kpetremann/mqtt-exporter",
+    )
+    parser.add_argument("--test", action="store_true")
+    args = parser.parse_args()
+
+    if args.test:
+        print("# Test conversion from a topic/payload parsing:\n")
+        topic = input("topic: ")
+        payload = input("payload: ")
+        print()
+
+        # clear registry
+        collectors = list(REGISTRY._collector_to_names.keys())
+        for collector in collectors:
+            REGISTRY.unregister(collector)
+
+        topic, payload = _parse_message(topic, payload)
+        print(f"parsed to: {topic} {payload}")
+
+        _parse_metrics(payload, topic, "", labels=None)
+        print("\n# Metrics:")
+        print(str(generate_latest().decode("utf-8")))
+    else:
+        run()
 
 
 if __name__ == "__main__":

--- a/mqtt_exporter/main.py
+++ b/mqtt_exporter/main.py
@@ -12,7 +12,14 @@ import sys
 from dataclasses import dataclass
 
 import paho.mqtt.client as mqtt
-from prometheus_client import Counter, Gauge, metrics, start_http_server, generate_latest, REGISTRY
+from prometheus_client import (
+    REGISTRY,
+    Counter,
+    Gauge,
+    generate_latest,
+    metrics,
+    start_http_server,
+)
 
 from mqtt_exporter import settings
 

--- a/mqtt_exporter/main.py
+++ b/mqtt_exporter/main.py
@@ -478,7 +478,6 @@ def main():
     args = parser.parse_args()
 
     if args.test:
-        print("# Test conversion from a topic/payload parsing:\n")
         topic = input("topic: ")
         payload = input("payload: ")
         print()
@@ -488,11 +487,12 @@ def main():
         for collector in collectors:
             REGISTRY.unregister(collector)
 
+        print("## Debug ##\n")
         topic, payload = _parse_message(topic, payload)
         print(f"parsed to: {topic} {payload}")
 
         _parse_metrics(payload, topic, "", labels=None)
-        print("\n# Metrics:")
+        print("\n## Result ##\n")
         print(str(generate_latest().decode("utf-8")))
     else:
         run()


### PR DESCRIPTION
Add an interactive test mode in CLI, to test the conversion of a topic+payload to a Prometheus metric.

Usage example
```sh
$ python ./exporter.py --test
topic: zigbee2mqtt/0x00157d00032b1234
payload: {"temperature":26.24,"humidity":45.37}

## Debug ##

parsed to: zigbee2mqtt_0x00157d00032b1234 {'temperature': 26.24, 'humidity': 45.37}
INFO:mqtt-exporter:creating prometheus metric: PromMetricId(name='mqtt_temperature', labels=())
INFO:mqtt-exporter:creating prometheus metric: PromMetricId(name='mqtt_humidity', labels=())

## Result ##

# HELP mqtt_temperature metric generated from MQTT message.
# TYPE mqtt_temperature gauge
mqtt_temperature{topic="zigbee2mqtt_0x00157d00032b1234"} 26.24
# HELP mqtt_humidity metric generated from MQTT message.
# TYPE mqtt_humidity gauge
mqtt_humidity{topic="zigbee2mqtt_0x00157d00032b1234"} 45.37
```