### PR TITLE
Handle plain state value string in raw_payload

### DIFF
--- a/mqtt_exporter/main.py
+++ b/mqtt_exporter/main.py
@@ -326,12 +326,19 @@ def _parse_message(raw_topic, raw_payload):
     """Parse topic and payload to have exposable information."""
     # parse MQTT payload
     try:
-        payload = json.loads(raw_payload)
-    except json.JSONDecodeError:
-        LOG.debug('failed to parse payload as JSON: "%s"', raw_payload)
-        return None, None
+        if not isinstance(raw_payload, str):
+            raw_payload = raw_payload.decode(json.detect_encoding(raw_payload))
     except UnicodeDecodeError:
         LOG.debug('encountered undecodable payload: "%s"', raw_payload)
+        return None, None
+
+    try:
+        if raw_payload in STATE_VALUES:
+            payload = STATE_VALUES[raw_payload]
+        else:
+            payload = json.loads(raw_payload)
+    except json.JSONDecodeError:
+        LOG.debug('failed to parse payload as JSON: "%s"', raw_payload)
         return None, None
 
     if raw_topic.startswith(settings.ZWAVE_TOPIC_PREFIX):

--- a/mqtt_exporter/main.py
+++ b/mqtt_exporter/main.py
@@ -332,14 +332,14 @@ def _parse_message(raw_topic, raw_payload):
         LOG.debug('encountered undecodable payload: "%s"', raw_payload)
         return None, None
 
-    try:
-        if raw_payload in STATE_VALUES:
-            payload = STATE_VALUES[raw_payload]
-        else:
+    if raw_payload in STATE_VALUES:
+        payload = STATE_VALUES[raw_payload]
+    else:
+        try:
             payload = json.loads(raw_payload)
-    except json.JSONDecodeError:
-        LOG.debug('failed to parse payload as JSON: "%s"', raw_payload)
-        return None, None
+        except json.JSONDecodeError:
+            LOG.debug('failed to parse payload as JSON: "%s"', raw_payload)
+            return None, None
 
     if raw_topic.startswith(settings.ZWAVE_TOPIC_PREFIX):
         topic, payload = _normalize_zwave2mqtt_format(raw_topic, payload)

--- a/tests/functional/test_parse_message.py
+++ b/tests/functional/test_parse_message.py
@@ -166,6 +166,26 @@ def test__parse_message__esphome_style():
     assert parsed_payload == {"temperature": 22.0}
 
 
+def test__parse_message__esphome_style__binary_sensor():
+    """Test message parsing with esphome style for a binary sensor."""
+    settings.ESPHOME_TOPIC_PREFIXES = ["esp", "ESP"]
+    topic = "esphome/outdoor/binary_sensor/sunlight/state"
+    payload = "ON"
+
+    parsed_topic, parsed_payload = _parse_message(topic, payload)
+
+    assert parsed_topic == "esphome_outdoor"
+    assert parsed_payload == {"sunlight": 1.0}
+
+    topic = "ESPHOME/indoor/binary_sensor/sunlight/state"
+    payload = "OFF"
+
+    parsed_topic, parsed_payload = _parse_message(topic, payload)
+
+    assert parsed_topic == "esphome_indoor"
+    assert parsed_payload == {"sunlight": 0.0}
+
+
 def test__parse_message__hubitat_style():
     """Test message parsing with Hubitat style.
 


### PR DESCRIPTION
Fixes/Implement: #82 

**Description:**

When parsing a message, check if it is one of the defined `STATE_VALUES`, and in that case, use that value instead of trying to parse using JSON.

**Before the commit:**

See the linked issue.

**After the commit:**

```
topic: freezer_open_detector/binary_sensor/freezer_open/state
payload: OFF

## Debug ##

parsed to: freezer_open_detector_binary_sensor {'state': 0}
INFO:mqtt-exporter:creating prometheus metric: PromMetricId(name='mqtt_state', labels=())

## Result ##

# HELP mqtt_state metric generated from MQTT message.
# TYPE mqtt_state gauge
mqtt_state{topic="freezer_open_detector_binary_sensor"} 0.0
```

