### PR TITLE
feat: add helmchart publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,3 +56,22 @@ jobs:
                   platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/ppc64le,linux/s390x
                   push: true
                   tags: ${{ steps.meta.outputs.tags }}
+
+    release_chart:
+        runs-on: ubuntu-latest
+        if: {{ github.ref == 'ref/head/v*' }}
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v3
+              with:
+                  fetch-depth: 0
+
+            - name: Configure Git
+              run: |
+                git config user.name "$GITHUB_ACTOR"
+                git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+            - name: Run chart-releaser
+              uses: helm/chart-releaser-action@v1.7.0
+              env:
+                  CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Fixes/Implement: #90

**Description:**

This PR adds a GitHub Action Workflow Job to publish the HelmChart that is already present in this repository. This Workflow Job will only run when a tag is pushed.

Before merging this Merge Request the used GitHub action requires that an empty branch called `gh-pages` is created and chosen for use with GitHub Pages in the repository settings.

After the first successful release with a chart, I will be opening a follow-up PR that will add the Helm repository to ArtifactHub.

P.S.: I have never implemented releasing charts with GitHub Actions and I have no idea how to test this PR before merging it. I am willing to do follow-up PRs if things should go south.

**Before the commit:**

HelmChart was only present in Git to deploy the application.

**After the commit:**

HelmChart is published and ready for public use.