### PR TITLE
fix(ci): fix condition for helm chart release

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -10,7 +10,7 @@ on:
 jobs:
     release:
         runs-on: ubuntu-latest
-        if: ${{ github.ref == 'ref/head/v*' }}
+        if: startsWith(github.ref, 'refs/tags/v')
         steps:
             - name: Checkout
               uses: actions/checkout@v3


### PR DESCRIPTION
<!-- Please respect the guidelines - codestyle and unit tests - explained in CONTRIBUTING.md -->

Fixes/Implement: #90 

**Description:**

Hopefully, this PR fixes the if condition that caused the Helm Chart publishing to be skipped.

**Before the commit:**

Helm Chart publishing was skipped on push of tag due to an incorrect if condition.

**After the commit:**

Helm Chart publishing should be executed on tags that start with a `v`.