### PR TITLE
Fix `mqtt-exporter` script

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = { file = ["requirements/base.txt"] }
 Homepage = "https://github.com/kpetremann/mqtt-exporter"
 
 [project.scripts]
-mqtt-exporter = "mqtt_exporter.main:main"
+mqtt-exporter = "mqtt_exporter.main:main_mqtt_exporter"
 
 [tool.setuptools]
 packages = ["mqtt_exporter"]


### PR DESCRIPTION
**Description:**
https://github.com/kpetremann/mqtt-exporter/commit/64067251f749b2e148d8270cb1288a3b1f9bef31 changed the name of `mqtt_exporter.main:main` to `mqtt_expoter.main:man_mqtt_exporter` but that change wasn't reflected in this project.

I noticed this because the NixOS package stopped working due to this change https://github.com/NixOS/nixpkgs/issues/466532 I patched the file locally and with this change everything works fine again.

**Before the commit:**

The configuration file points to the wrong function causing the program to file to start

**After the commit:**

The configuration file points to the correct function and everything works as intended