### PR TITLE
state values: ability to add more via environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ The list of parameters are:
   * `EXPOSE_LAST_SEEN`: Enable additional gauges exposing last seen timestamp for each metrics
   * `PARSE_MSG_PAYLOAD`: Enable parsing and metrics of the payload. (default: true)
   * `MAX_METRICS`: Maximum number of metrics to create. When limit is reached, new metrics will be ignored. Set to 0 for unlimited. (default: 2000)
+  * `STATE_VALUES`: Additional custom state value mappings (e.g., "OPEN=1,CLOSED=0,LOCKED=1,UNLOCKED=0"). These are merged with defaults: ON=1, OFF=0, TRUE=1, FALSE=0, ONLINE=1, OFFLINE=0 (default: "")
 
 ### Deployment
 

--- a/mqtt_exporter/main.py
+++ b/mqtt_exporter/main.py
@@ -30,14 +30,6 @@ logging.basicConfig(level=settings.LOG_LEVEL)
 LOG = logging.getLogger("mqtt-exporter")
 
 ZIGBEE2MQTT_AVAILABILITY_SUFFIX = "/availability"
-STATE_VALUES = {
-    "ON": 1,
-    "OFF": 0,
-    "TRUE": 1,
-    "FALSE": 0,
-    "ONLINE": 1,
-    "OFFLINE": 0,
-}
 
 
 @dataclass(frozen=True)
@@ -187,8 +179,8 @@ def _parse_metric(data):
         data = data.upper()
 
         # Handling of switch data where their state is reported as ON/OFF
-        if data in STATE_VALUES:
-            return STATE_VALUES[data]
+        if data in settings.STATE_VALUES:
+            return settings.STATE_VALUES[data]
 
         # Last ditch effort, we got a string, let's try to cast it
         return float(data)
@@ -373,8 +365,8 @@ def _parse_message(raw_topic, raw_payload):
         LOG.debug('encountered undecodable payload: "%s" (%s)', raw_payload, err)
         return None, None
 
-    if raw_payload in STATE_VALUES:
-        payload = STATE_VALUES[raw_payload]
+    if raw_payload in settings.STATE_VALUES:
+        payload = settings.STATE_VALUES[raw_payload]
     else:
         try:
             payload = json.loads(raw_payload)

--- a/mqtt_exporter/settings.py
+++ b/mqtt_exporter/settings.py
@@ -1,6 +1,9 @@
 """Exporter configuration."""
 
+import logging
 import os
+
+LOG = logging.getLogger("mqtt-exporter")
 
 PREFIX = os.getenv("PROMETHEUS_PREFIX", "mqtt_")
 TOPIC_LABEL = os.getenv("TOPIC_LABEL", "topic")
@@ -35,3 +38,27 @@ PROMETHEUS_ADDRESS = os.getenv("PROMETHEUS_ADDRESS", "0.0.0.0")
 PROMETHEUS_PORT = int(os.getenv("PROMETHEUS_PORT", "9000"))
 
 KEEP_FULL_TOPIC = os.getenv("KEEP_FULL_TOPIC", "False").lower() == "true"
+
+# State value mappings - can be extended via STATE_VALUES environment variable
+# Format: "KEY1=VALUE1,KEY2=VALUE2" (e.g., "OPEN=1,CLOSED=0,LOCKED=1,UNLOCKED=0")
+DEFAULT_STATE_VALUES = {
+    "ON": 1,
+    "OFF": 0,
+    "TRUE": 1,
+    "FALSE": 0,
+    "ONLINE": 1,
+    "OFFLINE": 0,
+}
+
+# Parse custom state values from environment variable
+STATE_VALUES = DEFAULT_STATE_VALUES.copy()
+custom_states = os.getenv("STATE_VALUES", "")
+if custom_states:
+    try:
+        for pair in custom_states.split(","):
+            if "=" in pair:
+                key, value = pair.split("=", 1)
+                STATE_VALUES[key.strip().upper()] = float(value.strip())
+    except (ValueError, AttributeError) as e:
+        # Log warning but continue with defaults
+        LOG.warning("Failed to parse STATE_VALUES environment variable: %s", e)


### PR DESCRIPTION
I added a new STATE_VALUES environment variable we can use to add more states without having to change the python code... my zigbww2mqtt has some sonoff trv's which specify "idle" and "heat" for their on or off :)