### PR TITLE
feat(helm): add support for Kubernetes Secret references in MQTT auth

### DIFF
--- a/charts/mqtt-exporter/templates/deployment.yaml
+++ b/charts/mqtt-exporter/templates/deployment.yaml
@@ -41,9 +41,23 @@ spec:
             - name: MQTT_ADDRESS
               value: {{ .Values.mqttExporter.mqtt.connection.address | quote }}
             - name: MQTT_USERNAME
+              {{- if .Values.mqttExporter.mqtt.connection.authentication.secretName }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.mqttExporter.mqtt.connection.authentication.secretName }}
+                  key: {{ .Values.mqttExporter.mqtt.connection.authentication.usernameKey | default "username" }}
+              {{- else }}
               value: {{ .Values.mqttExporter.mqtt.connection.authentication.username | quote }}
+              {{- end }}
             - name: MQTT_PASSWORD
+              {{- if .Values.mqttExporter.mqtt.connection.authentication.secretName }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.mqttExporter.mqtt.connection.authentication.secretName }}
+                  key: {{ .Values.mqttExporter.mqtt.connection.authentication.passwordKey | default "password" }}
+              {{- else }}
               value: {{ .Values.mqttExporter.mqtt.connection.authentication.password | quote }}
+              {{- end }}
             - name: MQTT_TLS_NO_VERIFY
               value: {{ .Values.mqttExporter.mqtt.connection.tls.noVerify | quote }}
             - name: MQTT_ENABLE_TLS

--- a/charts/mqtt-exporter/values.yaml
+++ b/charts/mqtt-exporter/values.yaml
@@ -18,6 +18,11 @@ mqttExporter:
       authentication:
         username: username
         password: password
+        # Optional: Reference an existing Kubernetes Secret for credentials
+        # When secretName is set, username/password values above are ignored
+        # secretName: mqtt-credentials
+        # usernameKey: username
+        # passwordKey: password
       tls:
         enable: false
         verify: true


### PR DESCRIPTION
## Summary

This PR adds support for referencing existing Kubernetes Secrets for MQTT authentication credentials in the Helm chart, addressing the security concern of storing credentials as plain text in values.yaml.

### Changes

- Added optional `secretName` parameter under `mqttExporter.mqtt.connection.authentication`
- Added optional `usernameKey` and `passwordKey` parameters for custom secret key names (defaults: "username", "password")
- Modified deployment template to use `valueFrom.secretKeyRef` when `secretName` is provided
- Maintains full backward compatibility - omitting `secretName` uses existing plain text behavior

### Usage

```yaml
mqttExporter:
  mqtt:
    connection:
      authentication:
        # Option 1: Plain text (existing behavior)
        username: myuser
        password: mypass
        
        # Option 2: Reference existing Secret
        secretName: mqtt-credentials
        # usernameKey: username  # optional, defaults to "username"
        # passwordKey: password  # optional, defaults to "password"
```

### Testing

Verified helm template renders correctly for all scenarios:
- ✅ Default (no secret): uses plain text values
- ✅ With secretName: uses secretKeyRef with default keys
- ✅ With secretName + custom keys: uses secretKeyRef with custom keys

Closes #107