### PR TITLE
Add `MQTT_PASSWORD_FILE` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,8 @@ The list of parameters are:
   * `MQTT_TOPIC`: Comma-separated lists of topics to subscribe to (default: #)
   * `MQTT_KEEPALIVE`: Keep alive interval to maintain connection with MQTT broker (default: 60)
   * `MQTT_USERNAME`: Username which should be used to authenticate against the MQTT broker (default: None)
-  * `MQTT_PASSWORD`: Password which should be used to authenticate against the MQTT broker (default: None)
+  * `MQTT_PASSWORD`: Password which should be used to authenticate against the MQTT broker (default: None). Mutually exclusive with `MQTT_PASSWORD_FILE`.
+  * `MQTT_PASSWORD_FILE`: File containing password which should be used to authenticate against the MQTT broker (default: None). Mutually exclusive with `MQTT_PASSWORD`.
   * `MQTT_V5_PROTOCOL`: Force to use MQTT protocol v5 instead of 3.1.1
   * `MQTT_CLIENT_ID`: Set client ID manually for MQTT connection
   * `MQTT_EXPOSE_CLIENT_ID`: Expose the client ID as a label in Prometheus metrics

--- a/mqtt_exporter/settings.py
+++ b/mqtt_exporter/settings.py
@@ -26,6 +26,14 @@ MQTT_PORT = int(os.getenv("MQTT_PORT", "1883"))
 MQTT_KEEPALIVE = int(os.getenv("MQTT_KEEPALIVE", "60"))
 MQTT_USERNAME = os.getenv("MQTT_USERNAME")
 MQTT_PASSWORD = os.getenv("MQTT_PASSWORD")
+MQTT_PASSWORD_FILE = os.getenv("MQTT_PASSWORD_FILE")
+
+if MQTT_PASSWORD_FILE:
+    if MQTT_PASSWORD:
+        raise ValueError("MQTT_PASSWORD_FILE is mutually exclusive with MQTT_PASSWORD")
+    with open(MQTT_PASSWORD_FILE, "r") as f:
+        MQTT_PASSWORD = f.read()
+
 MQTT_V5_PROTOCOL = os.getenv("MQTT_V5_PROTOCOL", "False").lower() == "true"
 MQTT_CLIENT_ID = os.getenv("MQTT_CLIENT_ID", "")
 MQTT_EXPOSE_CLIENT_ID = os.getenv("MQTT_EXPOSE_CLIENT_ID", "False").lower() == "true"


### PR DESCRIPTION
This allows people to pass a path to a file containing the secret, rather than having to embed the secret itself in an environment variable.
