### PR TITLE
Feature/add http route option to chart

### DIFF
--- a/charts/mqtt-exporter/Chart.yaml
+++ b/charts/mqtt-exporter/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/mqtt-exporter/Chart.yaml
+++ b/charts/mqtt-exporter/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/mqtt-exporter/templates/deployment.yaml
+++ b/charts/mqtt-exporter/templates/deployment.yaml
@@ -38,8 +38,6 @@ spec:
               value: {{ .Values.mqttExporter.mqtt.connection.address | quote }}
             - name: MQTT_PORT
               value: {{ .Values.mqttExporter.mqtt.connection.port | quote }}
-            - name: MQTT_ADDRESS
-              value: {{ .Values.mqttExporter.mqtt.connection.address | quote }}
             - name: MQTT_USERNAME
               {{- if .Values.mqttExporter.mqtt.connection.authentication.secretName }}
               valueFrom:

--- a/charts/mqtt-exporter/templates/http-route.yaml
+++ b/charts/mqtt-exporter/templates/http-route.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.route.main.enabled }}
+{{- $fullName := include "mqtt-exporter.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "mqtt-exporter.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs: {{ .Values.route.main.parentRefs | toYaml | nindent 4 }}
+  hostnames: {{ .Values.route.main.hostnames | toYaml | nindent 4 }}
+  rules:
+    - backendRefs:
+        - name: {{ $fullName }}
+          port: {{ $svcPort }}
+      matches:
+        - path:
+            type: PathPrefix
+            value: /
+{{- end }}

--- a/charts/mqtt-exporter/values.yaml
+++ b/charts/mqtt-exporter/values.yaml
@@ -85,6 +85,17 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
+route:
+  main:
+    enabled: false
+    hostnames:
+      - mqtt-exporter.example.com
+    parentRefs:
+      # - name: cilium-gateway
+      #   group: gateway.networking.k8s.io
+      #   kind: Gateway
+      #   namespace: kube-system
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
<!-- Please respect the guidelines - codestyle and unit tests - explained in CONTRIBUTING.md -->

Fixes/Implement: # 

**Description:**

<!-- Put here a simple description on what the change is supposed to do -->
Add the Option to the Helm-Chart to use http-route instead of ingress.

**Before the commit:**

<!-- When relevant, please provide output, screenshot or example before the change -->
Http-route was not implemented inside the Helm-Chart.

**After the commit:**

<!-- When relevant, please provide output, screenshot or example after the change -->
HTTP-Route is implemented inside the Helm-Chart
