### PR TITLE
feat: optional TTL for MQTT payload Prometheus metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ The list of parameters are:
   * `ESPHOME_TOPIC_PREFIXES`: MQTT topic used for ESPHome messages (default: "")
   * `HUBITAT_TOPIC_PREFIXES`: MQTT topic used for Hubitat messages (default: "hubitat/")
   * `EXPOSE_LAST_SEEN`: Enable additional gauges exposing last seen timestamp for each metrics
+  * `MQTT_METRICS_EXPIRE_SECONDS`: When set to a positive integer, remove Prometheus **payload** gauge time series that have not received an MQTT update within that many seconds (so Prometheus sees missing data instead of a frozen last value). Disabled when unset, empty, or zero. Does not apply to `message_total` counters. Set the TTL to several times your Prometheus `scrape_interval` to avoid flapping. Wall-clock jumps (NTP) can shift expiry timing slightly.
+  * `MQTT_METRICS_EXPIRE_INTERVAL_SECONDS`: Optional positive integer; seconds between internal TTL sweeps when expiry is enabled. If unset, the sweep interval defaults to `max(1, min(MQTT_METRICS_EXPIRE_SECONDS / 2, 30))`.
   * `PARSE_MSG_PAYLOAD`: Enable parsing and metrics of the payload. (default: true)
   * `PROMETHEUS_CERT`: Certificate to use for HTTPS. (default: None)
   * `PROMETHEUS_CERT_KEY`: Key file for the certificate. Note: you must specify both _CERT and _CERT_KEY, otherwise it will use plain http. (default: None)

--- a/charts/mqtt-exporter/templates/deployment.yaml
+++ b/charts/mqtt-exporter/templates/deployment.yaml
@@ -64,6 +64,14 @@ spec:
               value: {{ join "," .Values.mqttExporter.mqtt.ignored_topics | default "" | quote }}
             - name: LOG_LEVEL
               value: {{ .Values.mqttExporter.log.level | quote }}
+            {{- with .Values.mqttExporter.metrics.expire_seconds }}
+            - name: MQTT_METRICS_EXPIRE_SECONDS
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.mqttExporter.metrics.expire_interval_seconds }}
+            - name: MQTT_METRICS_EXPIRE_INTERVAL_SECONDS
+              value: {{ . | quote }}
+            {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/charts/mqtt-exporter/values.yaml
+++ b/charts/mqtt-exporter/values.yaml
@@ -29,6 +29,11 @@ mqttExporter:
   prometheus:
     prefix: mqtt_
     topic_label: topic
+  # Optional: remove stale payload metrics (see README MQTT_METRICS_EXPIRE_SECONDS).
+  # When null/omitted, the exporter does not expire metrics.
+  metrics:
+    expire_seconds: null
+    expire_interval_seconds: null
 
 image:
   repository: kpetrem/mqtt-exporter

--- a/mqtt_exporter/main.py
+++ b/mqtt_exporter/main.py
@@ -9,6 +9,7 @@ import re
 import signal
 import ssl
 import sys
+import threading
 import time
 from collections import defaultdict
 from dataclasses import dataclass
@@ -42,6 +43,116 @@ class PromMetricId:
 metric_refs: dict[str, list[tuple]] = defaultdict(list)
 prom_metrics: dict[PromMetricId, Gauge] = {}
 prom_msg_counter = None
+
+metrics_lock = threading.RLock()
+# (PromMetricId, label_values_tuple) -> unix time of last payload update; primary metrics only
+last_seen: dict[tuple[PromMetricId, tuple], float] = {}
+
+
+def _ordered_label_values(labels: dict, prom_metric_id: PromMetricId) -> tuple:
+    """Label values in the same order as the Gauge constructor for this metric."""
+    parts = [labels[settings.TOPIC_LABEL]]
+    if settings.MQTT_EXPOSE_CLIENT_ID:
+        parts.append(labels["client_id"])
+    for key in prom_metric_id.labels:
+        parts.append(labels[key])
+    return tuple(parts)
+
+
+def _last_seen_store_key(prom_metric_id: PromMetricId, labels: dict) -> tuple[PromMetricId, tuple]:
+    """Map a metric ref (including *_ts) to the last_seen dict key."""
+    if prom_metric_id.name.endswith("_ts"):
+        primary = PromMetricId(prom_metric_id.name[:-3], prom_metric_id.labels)
+        return (primary, _ordered_label_values(labels, primary))
+    return (prom_metric_id, _ordered_label_values(labels, prom_metric_id))
+
+
+def _prune_metric_refs_for_series(prom_metric_id: PromMetricId, labels: dict) -> None:
+    """Drop metric_refs entries for this primary metric and its optional *_ts companion."""
+    ts_id = None
+    if settings.EXPOSE_LAST_SEEN:
+        ts_id = PromMetricId(f"{prom_metric_id.name}_ts", prom_metric_id.labels)
+
+    for samples in metric_refs.values():
+        samples[:] = [
+            s
+            for s in samples
+            if not (
+                isinstance(s[1], dict)
+                and s[1] == labels
+                and (s[0] == prom_metric_id or (ts_id is not None and s[0] == ts_id))
+            )
+        ]
+
+
+def _remove_prometheus_series_for_ttl(prom_metric_id: PromMetricId, label_values: tuple) -> None:
+    """Remove one time series from the registry and bookkeeping (caller must hold metrics_lock)."""
+    try:
+        prom_metrics[prom_metric_id].remove(*label_values)
+    except KeyError:
+        pass
+
+    if settings.EXPOSE_LAST_SEEN:
+        ts_metric_id = PromMetricId(f"{prom_metric_id.name}_ts", prom_metric_id.labels)
+        if ts_metric_id in prom_metrics:
+            try:
+                prom_metrics[ts_metric_id].remove(*label_values)
+            except KeyError:
+                pass
+
+    labels_dict = {
+        settings.TOPIC_LABEL: label_values[0],
+    }
+    i = 1
+    if settings.MQTT_EXPOSE_CLIENT_ID:
+        labels_dict["client_id"] = label_values[i]
+        i += 1
+    for key in prom_metric_id.labels:
+        labels_dict[key] = label_values[i]
+        i += 1
+
+    _prune_metric_refs_for_series(prom_metric_id, labels_dict)
+    last_seen.pop((prom_metric_id, label_values), None)
+
+
+def _metrics_ttl_sweep_unlocked() -> None:
+    if settings.MQTT_METRICS_EXPIRE_SECONDS is None:
+        return
+    now = time.time()
+    ttl = settings.MQTT_METRICS_EXPIRE_SECONDS
+    stale = [k for k, ts in last_seen.items() if now - ts >= ttl]
+    for prom_metric_id, label_values in stale:
+        _remove_prometheus_series_for_ttl(prom_metric_id, label_values)
+        LOG.debug("expired stale metric series %s %s", prom_metric_id, label_values)
+
+
+def _metrics_ttl_sweep_loop() -> None:
+    interval = settings.mqtt_metrics_expire_sweep_interval_seconds()
+    while True:
+        try:
+            with metrics_lock:
+                _metrics_ttl_sweep_unlocked()
+        except Exception:
+            LOG.exception("metric TTL sweep failed")
+        time.sleep(interval)
+
+
+def metrics_ttl_sweep_once() -> None:
+    """Run a single TTL sweep (used by tests)."""
+    with metrics_lock:
+        _metrics_ttl_sweep_unlocked()
+
+
+def _start_metrics_ttl_sweep_thread() -> None:
+    if settings.MQTT_METRICS_EXPIRE_SECONDS is None:
+        return
+    t = threading.Thread(target=_metrics_ttl_sweep_loop, name="mqtt-exporter-ttl", daemon=True)
+    t.start()
+    LOG.info(
+        "metric TTL enabled: expire after %s s, sweep every %s s",
+        settings.MQTT_METRICS_EXPIRE_SECONDS,
+        settings.mqtt_metrics_expire_sweep_interval_seconds(),
+    )
 
 
 def _create_msg_counter_metrics():
@@ -112,52 +223,58 @@ def _normalize_prometheus_metric_label_name(prom_metric_label_name):
 
 def _create_prometheus_metric(prom_metric_id, original_topic):
     """Create Prometheus metric if does not exist."""
-    if not prom_metrics.get(prom_metric_id):
-        if settings.MAX_METRICS > 0 and len(prom_metrics) >= settings.MAX_METRICS:
-            raise MaximumMetricReached(
-                f"metric limit reached ({settings.MAX_METRICS}): cannot create new metric {prom_metric_id}"
+    with metrics_lock:
+        if not prom_metrics.get(prom_metric_id):
+            if settings.MAX_METRICS > 0 and len(prom_metrics) >= settings.MAX_METRICS:
+                raise MaximumMetricReached(
+                    f"metric limit reached ({settings.MAX_METRICS}): cannot create new metric {prom_metric_id}"
+                )
+
+            labels = [settings.TOPIC_LABEL]
+            if settings.MQTT_EXPOSE_CLIENT_ID:
+                labels.append("client_id")
+            labels.extend(prom_metric_id.labels)
+
+            prom_metrics[prom_metric_id] = Gauge(
+                prom_metric_id.name, "metric generated from MQTT message.", labels
             )
+            metric_refs[original_topic].append((prom_metric_id, labels))
 
-        labels = [settings.TOPIC_LABEL]
-        if settings.MQTT_EXPOSE_CLIENT_ID:
-            labels.append("client_id")
-        labels.extend(prom_metric_id.labels)
+            if settings.EXPOSE_LAST_SEEN:
+                ts_metric_id = PromMetricId(f"{prom_metric_id.name}_ts", prom_metric_id.labels)
+                prom_metrics[ts_metric_id] = Gauge(
+                    ts_metric_id.name, "timestamp of metric generated from MQTT message.", labels
+                )
+                metric_refs[original_topic].append((ts_metric_id, labels))
 
-        prom_metrics[prom_metric_id] = Gauge(
-            prom_metric_id.name, "metric generated from MQTT message.", labels
-        )
-        metric_refs[original_topic].append((prom_metric_id, labels))
-
-        if settings.EXPOSE_LAST_SEEN:
-            ts_metric_id = PromMetricId(f"{prom_metric_id.name}_ts", prom_metric_id.labels)
-            prom_metrics[ts_metric_id] = Gauge(
-                ts_metric_id.name, "timestamp of metric generated from MQTT message.", labels
-            )
-            metric_refs[original_topic].append((ts_metric_id, labels))
-
-        LOG.info("creating prometheus metric: %s", prom_metric_id)
+            LOG.info("creating prometheus metric: %s", prom_metric_id)
 
 
 def _add_prometheus_sample(
     topic, original_topic, prom_metric_id, metric_value, client_id, additional_labels
 ):
-    if prom_metric_id not in prom_metrics:
-        return
+    with metrics_lock:
+        if prom_metric_id not in prom_metrics:
+            return
 
-    labels = {settings.TOPIC_LABEL: topic}
-    if settings.MQTT_EXPOSE_CLIENT_ID:
-        labels["client_id"] = client_id
-    labels.update(additional_labels)
+        labels = {settings.TOPIC_LABEL: topic}
+        if settings.MQTT_EXPOSE_CLIENT_ID:
+            labels["client_id"] = client_id
+        labels.update(additional_labels)
 
-    prom_metrics[prom_metric_id].labels(**labels).set(metric_value)
-    if not (prom_metric_id, labels) not in metric_refs[original_topic]:
-        metric_refs[original_topic].append((prom_metric_id, labels))
+        prom_metrics[prom_metric_id].labels(**labels).set(metric_value)
+        if not (prom_metric_id, labels) not in metric_refs[original_topic]:
+            metric_refs[original_topic].append((prom_metric_id, labels))
 
-    if settings.EXPOSE_LAST_SEEN:
-        ts_metric_id = PromMetricId(f"{prom_metric_id.name}_ts", prom_metric_id.labels)
-        prom_metrics[ts_metric_id].labels(**labels).set(int(time.time()))
-        if not (ts_metric_id, labels) not in metric_refs[original_topic]:
-            metric_refs[original_topic].append((ts_metric_id, labels))
+        if settings.EXPOSE_LAST_SEEN:
+            ts_metric_id = PromMetricId(f"{prom_metric_id.name}_ts", prom_metric_id.labels)
+            prom_metrics[ts_metric_id].labels(**labels).set(int(time.time()))
+            if not (ts_metric_id, labels) not in metric_refs[original_topic]:
+                metric_refs[original_topic].append((ts_metric_id, labels))
+
+        if settings.MQTT_METRICS_EXPIRE_SECONDS is not None:
+            key = _last_seen_store_key(prom_metric_id, labels)
+            last_seen[key] = time.time()
 
     LOG.debug("new value for %s: %s", prom_metric_id, metric_value)
 
@@ -451,33 +568,40 @@ def _zigbee2mqtt_rename(msg):
 
     payload = json.loads(msg.payload)
     old_topic = f"zigbee2mqtt/{payload['data']['from']}"
-    if old_topic not in metric_refs:
-        return
+    with metrics_lock:
+        if old_topic not in metric_refs:
+            return
 
-    for sample in metric_refs[old_topic]:
-        try:
-            prom_metrics[sample[0]].remove(*sample[1].values())
-        except KeyError:
-            pass
+        for sample in metric_refs[old_topic]:
+            if isinstance(sample[1], dict):
+                last_seen.pop(_last_seen_store_key(sample[0], sample[1]), None)
+            try:
+                if isinstance(sample[1], dict):
+                    prom_metrics[sample[0]].remove(*_ordered_label_values(sample[1], sample[0]))
+            except KeyError:
+                pass
 
-    del metric_refs[old_topic]
+        del metric_refs[old_topic]
 
-    # Remove old availability metrics following renaming
+        # Remove old availability metrics following renaming
 
-    if not settings.ZIGBEE2MQTT_AVAILABILITY:
-        return
+        if not settings.ZIGBEE2MQTT_AVAILABILITY:
+            return
 
-    old_topic_availability = f"{old_topic}{ZIGBEE2MQTT_AVAILABILITY_SUFFIX}"
-    if old_topic_availability not in metric_refs:
-        return
+        old_topic_availability = f"{old_topic}{ZIGBEE2MQTT_AVAILABILITY_SUFFIX}"
+        if old_topic_availability not in metric_refs:
+            return
 
-    for sample in metric_refs[old_topic_availability]:
-        try:
-            prom_metrics[sample[0]].remove(*sample[1].values())
-        except KeyError:
-            pass
+        for sample in metric_refs[old_topic_availability]:
+            if isinstance(sample[1], dict):
+                last_seen.pop(_last_seen_store_key(sample[0], sample[1]), None)
+            try:
+                if isinstance(sample[1], dict):
+                    prom_metrics[sample[0]].remove(*_ordered_label_values(sample[1], sample[0]))
+            except KeyError:
+                pass
 
-    del metric_refs[old_topic_availability]
+        del metric_refs[old_topic_availability]
 
 
 def expose_metrics(_, userdata, msg):
@@ -582,6 +706,8 @@ def run():
         client_cafile=settings.PROMETHEUS_CA,
         client_capath=settings.PROMETHEUS_CA_DIR,
     )
+
+    _start_metrics_ttl_sweep_thread()
 
     # define mqtt client
     client.on_connect = subscribe

--- a/mqtt_exporter/settings.py
+++ b/mqtt_exporter/settings.py
@@ -18,6 +18,37 @@ PARSE_MSG_PAYLOAD = os.getenv("PARSE_MSG_PAYLOAD", "True").lower() == "true"
 # 2000 is a very large number of metrics already, but should be high enough to avoid breaking users' setup
 MAX_METRICS = int(os.getenv("MAX_METRICS", "2000"))
 
+# Remove Prometheus time series for MQTT payload metrics after this many seconds without an
+# update. Disabled when unset, empty, zero, or invalid (see README).
+_metrics_expire_raw = os.getenv("MQTT_METRICS_EXPIRE_SECONDS", "").strip()
+MQTT_METRICS_EXPIRE_SECONDS: int | None
+try:
+    if not _metrics_expire_raw or int(_metrics_expire_raw) <= 0:
+        MQTT_METRICS_EXPIRE_SECONDS = None
+    else:
+        MQTT_METRICS_EXPIRE_SECONDS = int(_metrics_expire_raw)
+except ValueError:
+    LOG.warning(
+        "Invalid MQTT_METRICS_EXPIRE_SECONDS=%r; metric expiry disabled.",
+        _metrics_expire_raw,
+    )
+    MQTT_METRICS_EXPIRE_SECONDS = None
+
+_metrics_expire_interval_raw = os.getenv("MQTT_METRICS_EXPIRE_INTERVAL_SECONDS", "").strip()
+MQTT_METRICS_EXPIRE_INTERVAL_SECONDS: int | None
+try:
+    if not _metrics_expire_interval_raw:
+        MQTT_METRICS_EXPIRE_INTERVAL_SECONDS = None
+    else:
+        v_interval = int(_metrics_expire_interval_raw)
+        MQTT_METRICS_EXPIRE_INTERVAL_SECONDS = v_interval if v_interval > 0 else None
+except ValueError:
+    LOG.warning(
+        "Invalid MQTT_METRICS_EXPIRE_INTERVAL_SECONDS=%r; using default sweep interval.",
+        _metrics_expire_interval_raw,
+    )
+    MQTT_METRICS_EXPIRE_INTERVAL_SECONDS = None
+
 
 ZIGBEE2MQTT_AVAILABILITY = os.getenv("ZIGBEE2MQTT_AVAILABILITY", "False").lower() == "true"
 LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO")
@@ -75,3 +106,12 @@ if custom_states:
     except (ValueError, AttributeError) as e:
         # Log warning but continue with defaults
         LOG.warning("Failed to parse STATE_VALUES environment variable: %s", e)
+
+
+def mqtt_metrics_expire_sweep_interval_seconds() -> int:
+    """Seconds between TTL sweeps when MQTT_METRICS_EXPIRE_SECONDS is enabled."""
+    if MQTT_METRICS_EXPIRE_SECONDS is None:
+        return 30
+    if MQTT_METRICS_EXPIRE_INTERVAL_SECONDS is not None:
+        return MQTT_METRICS_EXPIRE_INTERVAL_SECONDS
+    return max(1, min(MQTT_METRICS_EXPIRE_SECONDS // 2, 30))

--- a/tests/functional/test_expose_metrics.py
+++ b/tests/functional/test_expose_metrics.py
@@ -13,13 +13,15 @@ def _reset():
     collectors = list(prometheus_client.REGISTRY._collector_to_names.keys())
     for collector in collectors:
         prometheus_client.REGISTRY.unregister(collector)
+    main.prom_metrics = {}
+    main.last_seen.clear()
+    main.metric_refs.clear()
 
 
 def _exec(client_id, mocker, added_labels):
     _reset()
     settings.MQTT_CLIENT_ID = client_id
     main._create_msg_counter_metrics()
-    main.prom_metrics = {}
     userdata = {"client_id": client_id}
     msg = mocker.Mock()
     msg.topic = "zigbee2mqtt/garage"

--- a/tests/functional/test_max_metrics.py
+++ b/tests/functional/test_max_metrics.py
@@ -15,6 +15,8 @@ def _reset():
     for collector in collectors:
         prometheus_client.REGISTRY.unregister(collector)
     main.prom_metrics = {}
+    main.last_seen.clear()
+    main.metric_refs.clear()
 
 
 def test_max_metrics__unlimited(mocker):

--- a/tests/functional/test_metrics_ttl.py
+++ b/tests/functional/test_metrics_ttl.py
@@ -1,0 +1,82 @@
+"""Functional tests for MQTT_METRICS_EXPIRE_SECONDS."""
+
+from unittest.mock import patch
+
+import prometheus_client
+from prometheus_client import generate_latest
+
+from mqtt_exporter import main, settings
+
+
+def _reset():
+    # pylama: ignore=W0212
+    collectors = list(prometheus_client.REGISTRY._collector_to_names.keys())
+    for collector in collectors:
+        prometheus_client.REGISTRY.unregister(collector)
+    main.prom_metrics = {}
+    main.last_seen.clear()
+    main.metric_refs.clear()
+
+
+def test_metrics_ttl_removes_stale_series(mocker):
+    """Stale payload gauges are removed after TTL; message counter remains."""
+    _reset()
+    saved_ttl = settings.MQTT_METRICS_EXPIRE_SECONDS
+    saved_interval = settings.MQTT_METRICS_EXPIRE_INTERVAL_SECONDS
+    settings.MQTT_METRICS_EXPIRE_SECONDS = 60
+    settings.MQTT_METRICS_EXPIRE_INTERVAL_SECONDS = 30
+    settings.MQTT_EXPOSE_CLIENT_ID = False
+    settings.EXPOSE_LAST_SEEN = True
+    settings.MQTT_V5_PROTOCOL = False
+    settings.PARSE_MSG_PAYLOAD = True
+
+    try:
+        main._create_msg_counter_metrics()
+        userdata = {"client_id": ""}
+        msg = mocker.Mock()
+        msg.topic = "zigbee2mqtt/garage"
+        msg.payload = '{"temperature": "23.5", "humidity": "40.5"}'
+
+        with patch.object(main.time, "time", return_value=1_000_000.0):
+            main.expose_metrics(None, userdata, msg)
+
+        text_before = generate_latest().decode()
+        assert 'mqtt_temperature{topic="zigbee2mqtt_garage"}' in text_before
+        assert 'mqtt_temperature_ts{topic="zigbee2mqtt_garage"}' in text_before
+        assert "mqtt_message_total" in text_before
+
+        with patch.object(main.time, "time", return_value=1_000_000.0 + 120.0):
+            main.metrics_ttl_sweep_once()
+
+        text_after = generate_latest().decode()
+        # Empty metric families still emit HELP/TYPE lines; assert time series samples are gone.
+        assert 'mqtt_temperature{topic="zigbee2mqtt_garage"}' not in text_after
+        assert 'mqtt_temperature_ts{topic="zigbee2mqtt_garage"}' not in text_after
+        assert 'mqtt_humidity{topic="zigbee2mqtt_garage"}' not in text_after
+        assert "mqtt_message_total" in text_after
+    finally:
+        settings.MQTT_METRICS_EXPIRE_SECONDS = saved_ttl
+        settings.MQTT_METRICS_EXPIRE_INTERVAL_SECONDS = saved_interval
+
+
+def test_metrics_ttl_disabled_no_last_seen_updates(mocker):
+    """When TTL is disabled, last_seen stays empty."""
+    _reset()
+    saved_ttl = settings.MQTT_METRICS_EXPIRE_SECONDS
+    settings.MQTT_METRICS_EXPIRE_SECONDS = None
+    settings.MQTT_EXPOSE_CLIENT_ID = False
+    settings.MQTT_V5_PROTOCOL = False
+    settings.PARSE_MSG_PAYLOAD = True
+
+    try:
+        main._create_msg_counter_metrics()
+        userdata = {"client_id": ""}
+        msg = mocker.Mock()
+        msg.topic = "zigbee2mqtt/garage"
+        msg.payload = '{"temperature": "23.5"}'
+        main.expose_metrics(None, userdata, msg)
+        assert main.last_seen == {}
+        main.metrics_ttl_sweep_once()
+        assert 'mqtt_temperature{topic="zigbee2mqtt_garage"}' in generate_latest().decode()
+    finally:
+        settings.MQTT_METRICS_EXPIRE_SECONDS = saved_ttl

--- a/tests/functional/test_parse_metrics.py
+++ b/tests/functional/test_parse_metrics.py
@@ -26,6 +26,8 @@ def test_parse_metrics__nested_with_dash_in_metric_name():
 def test_metrics_escaping():
     """Verify that all keys are escaped properly."""
     main.prom_metrics = {}
+    main.last_seen.clear()
+    main.metric_refs.clear()
     original_topic = "test/topic"
     parsed_topic = "test_topic"
     parsed_payload = {
@@ -44,6 +46,8 @@ def test_metrics_escaping():
 def test_parse_metrics__value_is_list():
     """Verify if list recursion works properly."""
     main.prom_metrics = {}
+    main.last_seen.clear()
+    main.metric_refs.clear()
     original_topic = "test/topic"
     parsed_topic = "test_topic"
     parsed_payload = {"test_value": [1, 2]}


### PR DESCRIPTION
## Summary

This adds optional expiry for **MQTT payload** Prometheus gauge time series so that when a device stops publishing, Prometheus no longer scrapes a frozen last value. The feature is **disabled by default** unless `MQTT_METRICS_EXPIRE_SECONDS` is set to a positive integer.

## Behaviour

- Track last update time per time series and run a daemon sweeper thread (when enabled) that removes stale series using `Gauge.remove()`, consistent with the existing Zigbee2MQTT rename path.
- When `EXPOSE_LAST_SEEN` is enabled, companion `*_ts` series are removed together with the primary metric.
- `message_total` counters are unchanged (only series updated through `_add_prometheus_sample` participate).
- Optional `MQTT_METRICS_EXPIRE_INTERVAL_SECONDS` overrides the default sweep interval (`max(1, min(TTL/2, 30))` seconds).

## Docs and chart

- README documents the new environment variables and operational notes.
- Helm `values.yaml` exposes optional `mqttExporter.metrics.expire_seconds` / `expire_interval_seconds` wired in the deployment template.

## Tests

- Functional tests cover TTL removal and disabled mode; existing test resets clear `last_seen` and `metric_refs`.